### PR TITLE
Jvp and helper fixes

### DIFF
--- a/lineax/_operator.py
+++ b/lineax/_operator.py
@@ -1988,11 +1988,9 @@ def _(operator):
 
 @conj.register(TangentLinearOperator)
 def _(operator):
-    # Should be unreachable: TangentLinearOperator is used for a narrow set of
-    # operations only (mv; transpose) inside the JVP rule linear_solve_p.
-    raise NotImplementedError(
-        "Please open a GitHub issue: https://github.com/google/lineax"
-    )
+    c = lambda operator: conj(operator)
+    primal_out, tangent_out = eqx.filter_jvp(c, (operator.primal,), (operator.tangent,))
+    return TangentLinearOperator(primal_out, tangent_out)
 
 
 @conj.register(AddLinearOperator)

--- a/lineax/_solver/bicgstab.py
+++ b/lineax/_solver/bicgstab.py
@@ -24,7 +24,7 @@ from equinox.internal import ω
 from jaxtyping import Array, PyTree
 
 from .._misc import max_norm, tree_dot
-from .._operator import AbstractLinearOperator
+from .._operator import AbstractLinearOperator, conj
 from .._solution import RESULTS
 from .._solve import AbstractLinearSolver
 from .misc import preconditioner_and_y0
@@ -208,6 +208,12 @@ class BiCGStab(AbstractLinearSolver[_BiCGStabState]):
         operator = state
         transpose_options = {}
         return operator.transpose(), transpose_options
+
+    def conj(self, state: _BiCGStabState, options: dict[str, Any]):
+        del options
+        operator = state
+        conj_options = {}
+        return conj(operator), conj_options
 
     def allow_dependent_columns(self, operator):
         return False

--- a/lineax/_solver/cg.py
+++ b/lineax/_solver/cg.py
@@ -237,6 +237,13 @@ class _CG(AbstractLinearSolver[_CGState]):
         transpose_options = {}
         return transpose_state, transpose_options
 
+    def conj(self, state: _CGState, options: dict[str, Any]):
+        del options
+        psd_op, is_nsd = state
+        conj_state = conj(psd_op), is_nsd
+        conj_options = {}
+        return conj_state, conj_options
+
 
 class CG(_CG):
     """Conjugate gradient solver for linear systems.

--- a/lineax/_solver/cholesky.py
+++ b/lineax/_solver/cholesky.py
@@ -77,8 +77,14 @@ class Cholesky(AbstractLinearSolver[_CholeskyState]):
         return solution, RESULTS.successful, {}
 
     def transpose(self, state: _CholeskyState, options: dict[str, Any]):
-        # Matrix is symmetric anyway
-        return state, options
+        # Matrix is self-adjoint
+        factor, is_nsd = state
+        return (factor.conj(), is_nsd), options
+
+    def conj(self, state: _CholeskyState, options: dict[str, Any]):
+        # Matrix is self-adjoint
+        factor, is_nsd = state
+        return (factor.conj(), is_nsd), options
 
     def allow_dependent_columns(self, operator):
         return False

--- a/lineax/_solver/diagonal.py
+++ b/lineax/_solver/diagonal.py
@@ -81,6 +81,9 @@ class Diagonal(AbstractLinearSolver[_DiagonalState]):
         # Matrix is symmetric
         return state, options
 
+    def conj(self, state: _DiagonalState, options: dict[str, Any]):
+        return state.conj() if state is not None else state, options
+
     def allow_dependent_columns(self, operator):
         return not self.well_posed
 

--- a/lineax/_solver/gmres.py
+++ b/lineax/_solver/gmres.py
@@ -27,6 +27,7 @@ from jaxtyping import Array, ArrayLike, Bool, Float, PyTree
 from .._misc import max_norm, two_norm
 from .._operator import (
     AbstractLinearOperator,
+    conj,
     MatrixLinearOperator,
 )
 from .._solution import RESULTS
@@ -408,6 +409,12 @@ class GMRES(AbstractLinearSolver[_GMRESState]):
         operator = state
         transpose_options = {}
         return operator.transpose(), transpose_options
+
+    def conj(self, state: _GMRESState, options: dict[str, Any]):
+        del options
+        operator = state
+        conj_options = {}
+        return conj(operator), conj_options
 
     def allow_dependent_columns(self, operator):
         return False

--- a/lineax/_solver/lu.py
+++ b/lineax/_solver/lu.py
@@ -75,6 +75,16 @@ class LU(AbstractLinearSolver[_LUState]):
         transpose_options = {}
         return transpose_state, transpose_options
 
+    def conj(
+        self,
+        state: _LUState,
+        options: dict[str, Any],
+    ):
+        (lu, piv), packed_structures, transpose = state
+        conj_state = (lu.conj(), piv.conj()), packed_structures, not transpose
+        conj_options = {}
+        return conj_state, conj_options
+
     def allow_dependent_columns(self, operator):
         return False
 

--- a/lineax/_solver/qr.py
+++ b/lineax/_solver/qr.py
@@ -91,6 +91,16 @@ class QR(AbstractLinearSolver):
         transpose_options = {}
         return transpose_state, transpose_options
 
+    def conj(self, state: _QRState, options: dict[str, Any]):
+        (q, r), transpose, structures = state
+        conj_state = (
+            (q.conj(), r.conj()),
+            transpose,
+            structures,
+        )
+        conj_options = {}
+        return conj_state, conj_options
+
     def allow_dependent_columns(self, operator):
         rows = operator.out_size()
         columns = operator.in_size()

--- a/lineax/_solver/svd.py
+++ b/lineax/_solver/svd.py
@@ -86,6 +86,13 @@ class SVD(AbstractLinearSolver[_SVDState]):
         transpose_options = {}
         return transpose_state, transpose_options
 
+    def conj(self, state: _SVDState, options: dict[str, Any]):
+        del options
+        (u, s, vt), packed_structures = state
+        conj_state = (u.conj(), s, vt.conj()), packed_structures
+        conj_options = {}
+        return conj_state, conj_options
+
     def allow_dependent_columns(self, operator):
         return True
 

--- a/lineax/_solver/triangular.py
+++ b/lineax/_solver/triangular.py
@@ -92,6 +92,18 @@ class Triangular(AbstractLinearSolver[_TriangularState]):
         transpose_options = {}
         return transpose_state, transpose_options
 
+    def conj(self, state: _TriangularState, options: dict[str, Any]):
+        matrix, lower, unit_diagonal, packed_structures, transpose = state
+        conj_state = (
+            matrix.conj(),
+            lower,
+            unit_diagonal,
+            packed_structures,
+            transpose,
+        )
+        conj_options = {}
+        return conj_state, conj_options
+
     def allow_dependent_columns(self, operator):
         return False
 

--- a/lineax/_solver/tridiagonal.py
+++ b/lineax/_solver/tridiagonal.py
@@ -104,6 +104,12 @@ class Tridiagonal(AbstractLinearSolver[_TridiagonalState]):
         transpose_state = (transpose_diagonals, transposed_packed_structures)
         return transpose_state, options
 
+    def conj(self, state: _TridiagonalState, options: dict[str, Any]):
+        (diagonal, lower_diagonal, upper_diagonal), packed_structures = state
+        conj_diagonals = (diagonal.conj(), lower_diagonal.conj(), upper_diagonal.conj())
+        conj_state = (conj_diagonals, packed_structures)
+        return conj_state, options
+
     def allow_dependent_columns(self, operator):
         return False
 

--- a/tests/test_adjoint.py
+++ b/tests/test_adjoint.py
@@ -30,7 +30,7 @@ def test_adjoint(make_operator, dtype, getkey):
         tags = ()
         in_size = 5
         out_size = 3
-    operator = make_operator(matrix, tags)
+    operator = make_operator(getkey, matrix, tags)
     v1, v2 = jr.normal(getkey(), (in_size,), dtype=dtype), jr.normal(
         getkey(), (out_size,), dtype=dtype
     )

--- a/tests/test_jvp.py
+++ b/tests/test_jvp.py
@@ -62,8 +62,9 @@ def test_jvp(
             # This is the exception.
             t_matrix.at[jnp.arange(3), jnp.arange(3)].set(0)
 
+        make_op = ft.partial(make_operator, getkey)
         operator, t_operator = eqx.filter_jvp(
-            make_operator, (matrix, tags), (t_matrix, t_tags)
+            make_op, (matrix, tags), (t_matrix, t_tags)
         )
 
         if use_state:

--- a/tests/test_jvp_jvp.py
+++ b/tests/test_jvp_jvp.py
@@ -52,8 +52,9 @@ def test_jvp_jvp(
             getkey, solver, tags, num=4, dtype=dtype
         )
 
+        make_op = ft.partial(make_operator, getkey)
         t_make_operator = lambda p, t_p: eqx.filter_jvp(
-            make_operator, (p, tags), (t_p, t_tags)
+            make_op, (p, tags), (t_p, t_tags)
         )
         tt_make_operator = lambda p, t_p, tt_p, tt_t_p: eqx.filter_jvp(
             t_make_operator, (p, t_p), (tt_p, tt_t_p)

--- a/tests/test_transpose.py
+++ b/tests/test_transpose.py
@@ -45,7 +45,7 @@ class TestTranspose:
         _, make_operator, solver, tags, assert_transpose_fixture, dtype, getkey
     ):
         (matrix,) = construct_matrix(getkey, solver, tags, dtype=dtype)
-        operator = make_operator(matrix, tags)
+        operator = make_operator(getkey, matrix, tags)
         out_size, in_size = matrix.shape
         out_vec = jr.normal(getkey(), (out_size,), dtype=dtype)
         in_vec = jr.normal(getkey(), (in_size,), dtype=dtype)

--- a/tests/test_vmap.py
+++ b/tests/test_vmap.py
@@ -46,7 +46,7 @@ def test_vmap(
     if (make_matrix is construct_matrix) or pseudoinverse:
 
         def wrap_solve(matrix, vector):
-            operator = make_operator(matrix, tags)
+            operator = make_operator(getkey, matrix, tags)
             if use_state:
                 state = solver.init(operator, options={})
                 return lx.linear_solve(operator, vector, solver, state=state).value

--- a/tests/test_vmap_jvp.py
+++ b/tests/test_vmap_jvp.py
@@ -77,8 +77,9 @@ def test_vmap_jvp(
 
             def _make():
                 matrix, t_matrix = make_matrix(getkey, solver, tags, num=2, dtype=dtype)
+                make_op = ft.partial(make_operator, getkey)
                 operator, t_operator = eqx.filter_jvp(
-                    make_operator, (matrix, tags), (t_matrix, t_tags)
+                    make_op, (matrix, tags), (t_matrix, t_tags)
                 )
                 return matrix, t_matrix, operator, t_operator
 

--- a/tests/test_vmap_vmap.py
+++ b/tests/test_vmap_vmap.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import functools as ft
+
 import equinox as eqx
 import equinox.internal as eqxi
 import jax.numpy as jnp
@@ -96,9 +98,10 @@ def test_vmap_vmap(
             else:
                 vec = jr.normal(getkey(), (10, 10, out_size), dtype=dtype)
 
+            make_op = ft.partial(make_operator, getkey)
             operator = eqx.filter_vmap(
                 eqx.filter_vmap(
-                    make_operator,
+                    make_op,
                     in_axes=vmap1_op,
                     out_axes=out_axis1,
                 ),

--- a/tests/test_well_posed.py
+++ b/tests/test_well_posed.py
@@ -37,7 +37,7 @@ def test_small_wellposed(make_operator, solver, tags, ops, getkey, dtype):
     else:
         tol = 1e-4
     (matrix,) = construct_matrix(getkey, solver, tags, dtype=dtype)
-    operator = make_operator(matrix, tags)
+    operator = make_operator(getkey, matrix, tags)
     operator, matrix = ops(operator, matrix)
     assert shaped_allclose(operator.as_matrix(), matrix, rtol=tol, atol=tol)
     out_size, _ = matrix.shape


### PR DESCRIPTION
Since https://github.com/google/lineax/pull/64 is blocked by a bug, I'm taking functional changes to a separate PR (but not enabling tests for complex variables yet). This includes fixing JVP for `linear_solve`, fixing Cholesky solver transposition, changing the randomness source in helper to be reproducible, and adding `dtype` parametrization to more tests.