### PR TITLE
Now using strict dtype/rank promotion in tests.

### DIFF
--- a/lineax/__init__.py
+++ b/lineax/__init__.py
@@ -37,6 +37,7 @@ from ._operator import (
     materialise as materialise,
     MatrixLinearOperator as MatrixLinearOperator,
     MulLinearOperator as MulLinearOperator,
+    NegLinearOperator as NegLinearOperator,
     PyTreeLinearOperator as PyTreeLinearOperator,
     TaggedLinearOperator as TaggedLinearOperator,
     TangentLinearOperator as TangentLinearOperator,

--- a/lineax/_norm.py
+++ b/lineax/_norm.py
@@ -93,7 +93,9 @@ def _two_norm_jvp(x, tx):
     # This approach is a bit more expensive (more divisions), but should be more
     # numerically stable (`x` and `denominator` should be of the same scale; `tx` is of
     # unknown scale).
-    t_out = tree_dot((x**ω / denominator).ω, tx).real
+    with jax.numpy_dtype_promotion("standard"):
+        div = (x**ω / denominator).ω
+    t_out = tree_dot(div, tx).real
     t_out = jnp.where(pred, 0, t_out)
     return out, t_out
 

--- a/lineax/_solver/misc.py
+++ b/lineax/_solver/misc.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import math
+import warnings
 from typing import Any, NewType
 
 import equinox as eqx
@@ -97,7 +98,9 @@ def unravel_solution(
     sizes = np.cumsum([math.prod(x.shape) for x in leaves[:-1]])
     split = jnp.split(solution, sizes)
     assert len(split) == len(leaves)
-    shaped = [x.reshape(y.shape).astype(y.dtype) for x, y in zip(split, leaves)]
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")  # ignore complex-to-real cast warning
+        shaped = [x.reshape(y.shape).astype(y.dtype) for x, y in zip(split, leaves)]
     return jtu.tree_unflatten(treedef, shaped)
 
 

--- a/lineax/_solver/svd.py
+++ b/lineax/_solver/svd.py
@@ -72,7 +72,7 @@ class SVD(AbstractLinearSolver[_SVDState]):
         mask = s > rcond
         rank = mask.sum()
         safe_s = jnp.where(mask, s, 1)
-        s_inv = jnp.where(mask, jnp.array(1.0) / safe_s, 0)
+        s_inv = jnp.where(mask, jnp.array(1.0) / safe_s, 0).astype(u.dtype)
         uTb = jnp.matmul(u.conj().T, vector, precision=lax.Precision.HIGHEST)
         solution = jnp.matmul(vt.conj().T, s_inv * uTb, precision=lax.Precision.HIGHEST)
         solution = unravel_solution(solution, packed_structures)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,8 @@ import pytest
 
 
 jax.config.update("jax_enable_x64", True)
+jax.config.update("jax_numpy_dtype_promotion", "strict")
+jax.config.update("jax_numpy_rank_promotion", "raise")
 
 
 @pytest.fixture


### PR DESCRIPTION
- Now using strict dtype/rank promotion in tests.
- Introduced `NegLinearOperator` as part of the above.
- Now catching several spurious warnings.
- Fixed `is_{positive,negative}_semidefinite(:{Mul,Div}LinearOperator)`
    possibly producing the wrong result.
