### PR TITLE
Add Smoothers (Iterative Linear Solvers based on Matrix Decomposition)

### DIFF
--- a/lineax/__init__.py
+++ b/lineax/__init__.py
@@ -72,6 +72,7 @@ from ._tags import (
     lower_triangular_tag as lower_triangular_tag,
     negative_semidefinite_tag as negative_semidefinite_tag,
     positive_semidefinite_tag as positive_semidefinite_tag,
+    strictly_diagonally_dominant_tag as strictly_diagonally_dominant_tag,
     symmetric_tag as symmetric_tag,
     transpose_tags as transpose_tags,
     transpose_tags_rules as transpose_tags_rules,

--- a/lineax/__init__.py
+++ b/lineax/__init__.py
@@ -57,6 +57,7 @@ from ._solver import (
     CG as CG,
     Cholesky as Cholesky,
     Diagonal as Diagonal,
+    GaussSeidel as GaussSeidel,
     GMRES as GMRES,
     Jacobi as Jacobi,
     LU as LU,

--- a/lineax/__init__.py
+++ b/lineax/__init__.py
@@ -31,6 +31,7 @@ from ._operator import (
     is_lower_triangular as is_lower_triangular,
     is_negative_semidefinite as is_negative_semidefinite,
     is_positive_semidefinite as is_positive_semidefinite,
+    is_strictly_diagonally_dominant as is_strictly_diagonally_dominant,
     is_symmetric as is_symmetric,
     is_tridiagonal as is_tridiagonal,
     is_upper_triangular as is_upper_triangular,

--- a/lineax/__init__.py
+++ b/lineax/__init__.py
@@ -58,6 +58,7 @@ from ._solver import (
     Cholesky as Cholesky,
     Diagonal as Diagonal,
     GMRES as GMRES,
+    Jacobi as Jacobi,
     LU as LU,
     NormalCG as NormalCG,
     QR as QR,

--- a/lineax/_operator.py
+++ b/lineax/_operator.py
@@ -50,6 +50,7 @@ from ._tags import (
     lower_triangular_tag,
     negative_semidefinite_tag,
     positive_semidefinite_tag,
+    strictly_diagonally_dominant_tag,
     symmetric_tag,
     transpose_tags,
     tridiagonal_tag,
@@ -1780,6 +1781,42 @@ def _(operator):
 def _(operator):
     # TODO: refine this
     return False
+
+
+# is_strictly_diagonally_dominant
+
+
+@ft.singledispatch
+def is_strictly_diagonally_dominant(operator: AbstractLinearOperator) -> bool:
+    """Returns whether an operator is marked as strictly diagonally dominant.
+
+    See [the documentation on linear operator tags](../api/tags.md) for more
+    information.
+
+    **Arguments:**
+
+    - `operator`: a linear operator.
+
+    **Returns:**
+
+    Either `True` or `False.`
+    """
+    _default_not_implemented("is_strictly_diagonally_dominant", operator)
+
+
+@is_strictly_diagonally_dominant.register(MatrixLinearOperator)
+@is_strictly_diagonally_dominant.register(PyTreeLinearOperator)
+@is_strictly_diagonally_dominant.register(JacobianLinearOperator)
+@is_strictly_diagonally_dominant.register(FunctionLinearOperator)
+@is_strictly_diagonally_dominant.register(TridiagonalLinearOperator)
+def _(operator):
+    return strictly_diagonally_dominant_tag in operator.tags
+
+
+@is_strictly_diagonally_dominant.register(IdentityLinearOperator)
+@is_strictly_diagonally_dominant.register(DiagonalLinearOperator)
+def _(operator):
+    return True
 
 
 # ops for wrapper operators

--- a/lineax/_operator.py
+++ b/lineax/_operator.py
@@ -1961,6 +1961,7 @@ for check in (
     is_lower_triangular,
     is_upper_triangular,
     is_tridiagonal,
+    is_strictly_diagonally_dominant,
 ):
 
     @check.register(TangentLinearOperator)
@@ -2008,6 +2009,7 @@ for check, tag in (
     (is_positive_semidefinite, positive_semidefinite_tag),
     (is_negative_semidefinite, negative_semidefinite_tag),
     (is_tridiagonal, tridiagonal_tag),
+    (is_strictly_diagonally_dominant, strictly_diagonally_dominant_tag),
 ):
 
     @check.register(TaggedLinearOperator)
@@ -2023,6 +2025,7 @@ for check in (
     is_positive_semidefinite,
     is_negative_semidefinite,
     is_tridiagonal,
+    is_strictly_diagonally_dominant,
 ):
 
     @check.register(AddLinearOperator)
@@ -2043,6 +2046,7 @@ for check in (
     is_positive_semidefinite,
     is_negative_semidefinite,
     is_tridiagonal,
+    is_strictly_diagonally_dominant,
 ):
 
     @check.register(ComposedLinearOperator)

--- a/lineax/_solver/__init__.py
+++ b/lineax/_solver/__init__.py
@@ -16,6 +16,7 @@ from .bicgstab import BiCGStab as BiCGStab
 from .cg import CG as CG, NormalCG as NormalCG
 from .cholesky import Cholesky as Cholesky
 from .diagonal import Diagonal as Diagonal
+from .gauss_seidel import GaussSeidel as GaussSeidel
 from .gmres import GMRES as GMRES
 from .jacobi import Jacobi as Jacobi
 from .lu import LU as LU

--- a/lineax/_solver/__init__.py
+++ b/lineax/_solver/__init__.py
@@ -17,6 +17,7 @@ from .cg import CG as CG, NormalCG as NormalCG
 from .cholesky import Cholesky as Cholesky
 from .diagonal import Diagonal as Diagonal
 from .gmres import GMRES as GMRES
+from .jacobi import Jacobi as Jacobi
 from .lu import LU as LU
 from .qr import QR as QR
 from .svd import SVD as SVD

--- a/lineax/_solver/gauss_seidel.py
+++ b/lineax/_solver/gauss_seidel.py
@@ -1,0 +1,193 @@
+from typing import Any, Callable, Optional
+from typing_extensions import TypeAlias
+
+import jax
+import jax.lax as lax
+import jax.numpy as jnp
+import jax.tree_util as jtu
+from equinox.internal import ω
+from jaxtyping import Array, PyTree
+
+from .._norm import max_norm
+from .._operator import AbstractLinearOperator
+from .._solution import RESULTS
+from .._solve import AbstractLinearSolver
+from .misc import (
+    pack_structures,
+    PackedStructures,
+    ravel_vector,
+    transpose_packed_structures,
+    unravel_solution,
+)
+
+
+_GaussSeidelState: TypeAlias = tuple[tuple[Array, Array], PackedStructures]
+
+
+class GaussSeidel(AbstractLinearSolver[_GaussSeidelState], strict=False):
+    rtol: float
+    atol: float
+    norm: Callable = max_norm
+    max_steps: Optional[int] = None
+
+    def __check_init__(self):
+        if isinstance(self.rtol, (int, float)) and self.rtol < 0:
+            raise ValueError("Tolerances must be non-negative.")
+        if isinstance(self.atol, (int, float)) and self.atol < 0:
+            raise ValueError("Tolerances must be non-negative.")
+
+        if isinstance(self.atol, (int, float)) and isinstance(self.rtol, (int, float)):
+            if self.atol == 0 and self.rtol == 0 and self.max_steps is None:
+                raise ValueError(
+                    "Must specify `rtol`, `atol`, or `max_steps` (or some combination "
+                    "of all three)."
+                )
+
+    def init(
+        self, operator: AbstractLinearOperator, options: dict[str, Any]
+    ) -> _GaussSeidelState:
+        del options
+
+        packed_structures = pack_structures(operator)
+        # Needs to materialize the system matrix to decompose it
+        system_matrix = operator.as_matrix()
+        strictly_upper = jnp.triu(system_matrix, k=1)
+        lower = system_matrix - strictly_upper
+        return (lower, strictly_upper), packed_structures
+
+    def compute(
+        self,
+        state: _GaussSeidelState,
+        vector: PyTree[Array],
+        options: dict[str, Any],
+    ) -> tuple[PyTree[Array], RESULTS, dict[str, Any]]:
+        (lower, strictly_upper), packed_structures = state
+
+        leaves, _ = jtu.tree_flatten(vector)
+        if self.max_steps is None:
+            size = sum(leaf.size for leaf in leaves)
+            max_steps = 10 * size
+        else:
+            max_steps = self.max_steps
+
+        # Ravel the PyTree right hand side into a single vector to operate with
+        # the materialized matrices
+        vector = ravel_vector(vector, packed_structures)
+
+        has_scale = not (
+            isinstance(self.atol, (int, float))
+            and isinstance(self.rtol, (int, float))
+            and self.atol == 0
+            and self.rtol == 0
+        )
+        if has_scale:
+            b_scale = (self.atol + self.rtol * ω(vector).call(jnp.abs)).ω
+
+        def compute_residual(y):
+            return vector - (lower + strictly_upper) @ y
+
+        def not_converged(r, diff, y):
+            # The primary tolerance check.
+            # Given Ay=b, then we have to be doing better than `scale` in both
+            # the `y` and the `b` spaces.
+            if has_scale:
+                with jax.numpy_dtype_promotion("standard"):
+                    y_scale = (self.atol + self.rtol * ω(y).call(jnp.abs)).ω
+                    norm1 = self.norm((r**ω / b_scale**ω).ω)  # pyright: ignore
+                    norm2 = self.norm((diff**ω / y_scale**ω).ω)
+                return (norm1 > 1) | (norm2 > 1)
+            else:
+                return True
+
+        def cond_fun(carry):
+            diff, y, r, step = carry
+            out = step < max_steps
+            out = out & not_converged(r, diff, y)
+            return out
+
+        def body_fun(carry):
+            _, y, _, step = carry
+            y_prev = y
+            y = jax.scipy.linalg.solve_triangular(
+                lower,
+                vector - strictly_upper @ y_prev,
+                lower=True,
+            )
+            diff = y - y_prev
+            r = compute_residual(y)
+            step = step + 1
+            return diff, y, r, step
+
+        try:
+            y0 = options["y0"]
+        except KeyError:
+            y0 = jtu.tree_map(jnp.zeros_like, vector)
+
+        r0 = compute_residual(y0)
+
+        initial_carry = (
+            ω(y0).call(lambda x: jnp.full_like(x, jnp.inf)).ω,
+            y0,
+            r0,
+            0,
+        )
+
+        _, solution, _, num_steps = lax.while_loop(cond_fun, body_fun, initial_carry)
+
+        if (self.max_steps is None) or (max_steps < self.max_steps):
+            result = RESULTS.where(
+                num_steps == max_steps,
+                RESULTS.singular,
+                RESULTS.successful,
+            )
+        else:
+            result = RESULTS.where(
+                num_steps == max_steps,
+                RESULTS.max_steps_reached,
+                RESULTS.successful,
+            )
+
+        solution = unravel_solution(solution, packed_structures)
+        stats = {"num_steps": num_steps, "max_steps": self.max_steps}
+        return solution, result, stats
+
+    def transpose(self, state: _GaussSeidelState, options: dict[str, Any]):
+        del options
+        (diagonal, strictly_lower_upper), packed_structures = state
+        transposed_strictly_lower_upper = jnp.transpose(strictly_lower_upper)
+        transposed_packed_structures = transpose_packed_structures(packed_structures)
+        transpose_state = (
+            (diagonal, transposed_strictly_lower_upper),
+            transposed_packed_structures,
+        )
+        transpose_options = {}
+        return transpose_state, transpose_options
+
+    def conj(self, state: _GaussSeidelState, options: dict[str, Any]):
+        del options
+        (diagonal, strictly_lower_upper), packed_structures = state
+        conjugated_strictly_lower_upper = jnp.conj(strictly_lower_upper)
+        conjugated_diagonal = jnp.conj(diagonal)
+        conjugated_state = (
+            (conjugated_diagonal, conjugated_strictly_lower_upper),
+            packed_structures,
+        )
+        conjugated_options = {}
+        return conjugated_state, conjugated_options
+
+    def allow_dependent_columns(self, operator):
+        return False
+
+    def allow_dependent_rows(self, operator):
+        return False
+
+
+GaussSeidel.__init__.__doc__ = """**Arguments:**
+
+- `rtol`: Relative tolerance for terminating solve.
+- `atol`: Absolute tolerance for terminating solve.
+- `norm`: The norm to use when computing whether the error falls within the tolerance.
+    Defaults to the max norm.
+- `max_steps`: The maximum number of iterations to run the solver for. If more steps
+    than this are required, then the solve is halted with a failure.
+"""

--- a/lineax/_solver/gauss_seidel.py
+++ b/lineax/_solver/gauss_seidel.py
@@ -66,7 +66,9 @@ class GaussSeidel(AbstractLinearSolver[_GaussSeidelState], strict=False):
         leaves, _ = jtu.tree_flatten(vector)
         if self.max_steps is None:
             size = sum(leaf.size for leaf in leaves)
-            max_steps = 10 * size
+            # This differs from the Krylov solvers (CG, NormalCG, BiCGStab,
+            # GMRES) because Smoothers typically converge way slower
+            max_steps = 100 * size
         else:
             max_steps = self.max_steps
 

--- a/lineax/_solver/gauss_seidel.py
+++ b/lineax/_solver/gauss_seidel.py
@@ -143,7 +143,7 @@ class GaussSeidel(AbstractLinearSolver[_GaussSeidelState], strict=False):
         else:
             result = RESULTS.where(
                 num_steps == max_steps,
-                RESULTS.max_steps_reached,
+                RESULTS.max_steps_reached if has_scale else RESULTS.successful,
                 RESULTS.successful,
             )
 

--- a/lineax/_solver/jacobi.py
+++ b/lineax/_solver/jacobi.py
@@ -1,0 +1,192 @@
+from typing import Any, Callable, Optional
+from typing_extensions import TypeAlias
+
+import jax
+import jax.lax as lax
+import jax.numpy as jnp
+import jax.tree_util as jtu
+from equinox.internal import ω
+from jaxtyping import Array, PyTree
+
+from .._norm import max_norm
+from .._operator import AbstractLinearOperator
+from .._solution import RESULTS
+from .._solve import AbstractLinearSolver
+from .misc import (
+    pack_structures,
+    PackedStructures,
+    ravel_vector,
+    transpose_packed_structures,
+    unravel_solution,
+)
+
+
+_JacobiState: TypeAlias = tuple[tuple[Array, Array], PackedStructures]
+
+
+class Jacobi(AbstractLinearSolver[_JacobiState], strict=False):
+    rtol: float
+    atol: float
+    norm: Callable = max_norm
+    max_steps: Optional[int] = None
+
+    def __check_init__(self):
+        if isinstance(self.rtol, (int, float)) and self.rtol < 0:
+            raise ValueError("Tolerances must be non-negative.")
+        if isinstance(self.atol, (int, float)) and self.atol < 0:
+            raise ValueError("Tolerances must be non-negative.")
+
+        if isinstance(self.atol, (int, float)) and isinstance(self.rtol, (int, float)):
+            if self.atol == 0 and self.rtol == 0 and self.max_steps is None:
+                raise ValueError(
+                    "Must specify `rtol`, `atol`, or `max_steps` (or some combination "
+                    "of all three)."
+                )
+
+    def init(
+        self, operator: AbstractLinearOperator, options: dict[str, Any]
+    ) -> _JacobiState:
+        del options
+
+        packed_structures = pack_structures(operator)
+        # Needs to materialize the system matrix to extract the diagonal
+        system_matrix = operator.as_matrix()
+        diagonal = jnp.diag(system_matrix)
+        # inverse_diagonal = 1.0 / diagonal
+        strictly_lower = jnp.tril(system_matrix, k=-1)
+        strictly_upper = jnp.triu(system_matrix, k=1)
+        strictly_lower_upper = strictly_lower + strictly_upper
+        return (diagonal, strictly_lower_upper), packed_structures
+
+    def compute(
+        self,
+        state: _JacobiState,
+        vector: PyTree[Array],
+        options: dict[str, Any],
+    ) -> tuple[PyTree[Array], RESULTS, dict[str, Any]]:
+        (diagonal, strictly_lower_upper), packed_structures = state
+
+        leaves, _ = jtu.tree_flatten(vector)
+        if self.max_steps is None:
+            size = sum(leaf.size for leaf in leaves)
+            max_steps = 10 * size
+        else:
+            max_steps = self.max_steps
+
+        # Ravel the PyTree right hand side into a single vector to operate with
+        # the materialized matrices
+        vector = ravel_vector(vector, packed_structures)
+
+        has_scale = not (
+            isinstance(self.atol, (int, float))
+            and isinstance(self.rtol, (int, float))
+            and self.atol == 0
+            and self.rtol == 0
+        )
+        if has_scale:
+            b_scale = (self.atol + self.rtol * ω(vector).call(jnp.abs)).ω
+
+        def compute_residual(y):
+            return vector - (strictly_lower_upper + jnp.diag(diagonal)) @ y
+
+        def not_converged(r, diff, y):
+            # The primary tolerance check.
+            # Given Ay=b, then we have to be doing better than `scale` in both
+            # the `y` and the `b` spaces.
+            if has_scale:
+                with jax.numpy_dtype_promotion("standard"):
+                    y_scale = (self.atol + self.rtol * ω(y).call(jnp.abs)).ω
+                    norm1 = self.norm((r**ω / b_scale**ω).ω)  # pyright: ignore
+                    norm2 = self.norm((diff**ω / y_scale**ω).ω)
+                return (norm1 > 1) | (norm2 > 1)
+            else:
+                return True
+
+        def cond_fun(carry):
+            diff, y, r, step = carry
+            out = step < max_steps
+            out = out & not_converged(r, diff, y)
+            return out
+
+        def body_fun(carry):
+            _, y, _, step = carry
+            y_prev = y
+            y = (vector - strictly_lower_upper @ y_prev) / diagonal
+            diff = y - y_prev
+            r = vector - (strictly_lower_upper + jnp.diag(diagonal)) @ y
+            step = step + 1
+            return diff, y, r, step
+
+        try:
+            y0 = options["y0"]
+        except KeyError:
+            y0 = jtu.tree_map(jnp.zeros_like, vector)
+
+        r0 = compute_residual(y0)
+
+        initial_carry = (
+            ω(y0).call(lambda x: jnp.full_like(x, jnp.inf)).ω,
+            y0,
+            r0,
+            0,
+        )
+
+        _, solution, _, num_steps = lax.while_loop(cond_fun, body_fun, initial_carry)
+
+        if (self.max_steps is None) or (max_steps < self.max_steps):
+            result = RESULTS.where(
+                num_steps == max_steps,
+                RESULTS.singular,
+                RESULTS.successful,
+            )
+        else:
+            result = RESULTS.where(
+                num_steps == max_steps,
+                RESULTS.max_steps_reached if has_scale else RESULTS.successful,
+                RESULTS.successful,
+            )
+
+        solution = unravel_solution(solution, packed_structures)
+        stats = {"num_steps": num_steps, "max_steps": self.max_steps}
+        return solution, result, stats
+
+    def transpose(self, state: _JacobiState, options: dict[str, Any]):
+        del options
+        (diagonal, strictly_lower_upper), packed_structures = state
+        transposed_strictly_lower_upper = jnp.transpose(strictly_lower_upper)
+        transposed_packed_structures = transpose_packed_structures(packed_structures)
+        transpose_state = (
+            (diagonal, transposed_strictly_lower_upper),
+            transposed_packed_structures,
+        )
+        transpose_options = {}
+        return transpose_state, transpose_options
+
+    def conj(self, state: _JacobiState, options: dict[str, Any]):
+        del options
+        (diagonal, strictly_lower_upper), packed_structures = state
+        conjugated_strictly_lower_upper = jnp.conj(strictly_lower_upper)
+        conjugated_diagonal = jnp.conj(diagonal)
+        conjugated_state = (
+            (conjugated_diagonal, conjugated_strictly_lower_upper),
+            packed_structures,
+        )
+        conjugated_options = {}
+        return conjugated_state, conjugated_options
+
+    def allow_dependent_columns(self, operator):
+        return False
+
+    def allow_dependent_rows(self, operator):
+        return False
+
+
+Jacobi.__init__.__doc__ = """**Arguments:**
+
+- `rtol`: Relative tolerance for terminating solve.
+- `atol`: Absolute tolerance for terminating solve.
+- `norm`: The norm to use when computing whether the error falls within the tolerance.
+    Defaults to the max norm.
+- `max_steps`: The maximum number of iterations to run the solver for. If more steps
+    than this are required, then the solve is halted with a failure.
+"""

--- a/lineax/_solver/jacobi.py
+++ b/lineax/_solver/jacobi.py
@@ -49,10 +49,9 @@ class Jacobi(AbstractLinearSolver[_JacobiState], strict=False):
         del options
 
         packed_structures = pack_structures(operator)
-        # Needs to materialize the system matrix to extract the diagonal
+        # Needs to materialize the system matrix to decompose it
         system_matrix = operator.as_matrix()
         diagonal = jnp.diag(system_matrix)
-        # inverse_diagonal = 1.0 / diagonal
         strictly_lower = jnp.tril(system_matrix, k=-1)
         strictly_upper = jnp.triu(system_matrix, k=1)
         strictly_lower_upper = strictly_lower + strictly_upper

--- a/lineax/_solver/jacobi.py
+++ b/lineax/_solver/jacobi.py
@@ -68,7 +68,9 @@ class Jacobi(AbstractLinearSolver[_JacobiState], strict=False):
         leaves, _ = jtu.tree_flatten(vector)
         if self.max_steps is None:
             size = sum(leaf.size for leaf in leaves)
-            max_steps = 10 * size
+            # This differs from the Krylov solvers (CG, NormalCG, BiCGStab,
+            # GMRES) because Smoothers typically converge way slower
+            max_steps = 100 * size
         else:
             max_steps = self.max_steps
 

--- a/lineax/_tags.py
+++ b/lineax/_tags.py
@@ -29,6 +29,7 @@ lower_triangular_tag = _HasRepr("lower_triangular_tag")
 upper_triangular_tag = _HasRepr("upper_triangular_tag")
 positive_semidefinite_tag = _HasRepr("positive_semidefinite_tag")
 negative_semidefinite_tag = _HasRepr("negative_semidefinite_tag")
+strictly_diagonally_dominant_tag = _HasRepr("strictly_diagonally_dominant_tag")
 
 
 transpose_tags_rules = []
@@ -41,6 +42,7 @@ for tag in (
     positive_semidefinite_tag,
     negative_semidefinite_tag,
     tridiagonal_tag,
+    strictly_diagonally_dominant_tag,
 ):
 
     @transpose_tags_rules.append

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -36,6 +36,9 @@ def _construct_matrix_impl(getkey, cond_cutoff, tags, size, dtype, i):
             matrix = jnp.diag(jnp.diag(matrix))
         if has_tag(tags, lx.symmetric_tag):
             matrix = matrix + matrix.T
+        if has_tag(tags, lx.strictly_diagonally_dominant_tag):
+            row_sum = (jnp.sum(jnp.abs(matrix), axis=0) + 0.1).astype(dtype)
+            matrix += jnp.diag(row_sum)
         if has_tag(tags, lx.lower_triangular_tag):
             matrix = jnp.tril(matrix)
         if has_tag(tags, lx.upper_triangular_tag):

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -116,6 +116,7 @@ solvers_tags_pseudoinverse = [
     (lx.Cholesky(), lx.positive_semidefinite_tag, False),
     (lx.Cholesky(), lx.negative_semidefinite_tag, False),
     (lx.Jacobi(rtol=tol, atol=tol), (), False),
+    (lx.GaussSeidel(rtol=tol, atol=tol), (), False),
 ]
 solvers_tags = [(a, b) for a, b, _ in solvers_tags_pseudoinverse]
 solvers = [a for a, _, _ in solvers_tags_pseudoinverse]

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -95,8 +95,10 @@ def construct_poisson_matrix(size, dtype=jnp.float64):
 
 if jax.config.jax_enable_x64:  # pyright: ignore
     tol = 1e-12
+    smoother_tol = 1e-10
 else:
     tol = 1e-6
+    smoother_tol = 1e-5
 solvers_tags_pseudoinverse = [
     (lx.AutoLinearSolver(well_posed=True), (), False),
     (lx.AutoLinearSolver(well_posed=False), (), True),
@@ -118,8 +120,16 @@ solvers_tags_pseudoinverse = [
     (lx.NormalCG(rtol=tol, atol=tol), lx.negative_semidefinite_tag, False),
     (lx.Cholesky(), lx.positive_semidefinite_tag, False),
     (lx.Cholesky(), lx.negative_semidefinite_tag, False),
-    (lx.Jacobi(rtol=tol, atol=tol), (), False),
-    (lx.GaussSeidel(rtol=tol, atol=tol), (), False),
+    (
+        lx.Jacobi(rtol=smoother_tol, atol=smoother_tol),
+        (lx.strictly_diagonally_dominant_tag),
+        False,
+    ),
+    (
+        lx.GaussSeidel(rtol=smoother_tol, atol=smoother_tol),
+        (lx.strictly_diagonally_dominant_tag),
+        False,
+    ),
 ]
 solvers_tags = [(a, b) for a, b, _ in solvers_tags_pseudoinverse]
 solvers = [a for a, _, _ in solvers_tags_pseudoinverse]

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -115,6 +115,7 @@ solvers_tags_pseudoinverse = [
     (lx.NormalCG(rtol=tol, atol=tol), lx.negative_semidefinite_tag, False),
     (lx.Cholesky(), lx.positive_semidefinite_tag, False),
     (lx.Cholesky(), lx.negative_semidefinite_tag, False),
+    (lx.Jacobi(rtol=tol, atol=tol), (), False),
 ]
 solvers_tags = [(a, b) for a, b, _ in solvers_tags_pseudoinverse]
 solvers = [a for a, _, _ in solvers_tags_pseudoinverse]

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -95,10 +95,8 @@ def construct_poisson_matrix(size, dtype=jnp.float64):
 
 if jax.config.jax_enable_x64:  # pyright: ignore
     tol = 1e-12
-    smoother_tol = 1e-10
 else:
     tol = 1e-6
-    smoother_tol = 1e-5
 solvers_tags_pseudoinverse = [
     (lx.AutoLinearSolver(well_posed=True), (), False),
     (lx.AutoLinearSolver(well_posed=False), (), True),
@@ -120,16 +118,8 @@ solvers_tags_pseudoinverse = [
     (lx.NormalCG(rtol=tol, atol=tol), lx.negative_semidefinite_tag, False),
     (lx.Cholesky(), lx.positive_semidefinite_tag, False),
     (lx.Cholesky(), lx.negative_semidefinite_tag, False),
-    (
-        lx.Jacobi(rtol=smoother_tol, atol=smoother_tol),
-        (lx.strictly_diagonally_dominant_tag),
-        False,
-    ),
-    (
-        lx.GaussSeidel(rtol=smoother_tol, atol=smoother_tol),
-        (lx.strictly_diagonally_dominant_tag),
-        False,
-    ),
+    (lx.Jacobi(rtol=tol, atol=tol), (lx.strictly_diagonally_dominant_tag), False),
+    (lx.GaussSeidel(rtol=tol, atol=tol), (lx.strictly_diagonally_dominant_tag), False),
 ]
 solvers_tags = [(a, b) for a, b, _ in solvers_tags_pseudoinverse]
 solvers = [a for a, _, _ in solvers_tags_pseudoinverse]

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -281,6 +281,26 @@ def test_is_tridiagonal(dtype, getkey):
 
 
 @pytest.mark.parametrize("dtype", (jnp.float64, jnp.complex128))
+def test_is_strictly_diagonally_dominant(dtype, getkey):
+    matrix = jr.normal(getkey(), (3, 3), dtype=dtype)
+    not_strictly_diagonally_dominant = _setup(getkey, matrix)
+
+    for operator in not_strictly_diagonally_dominant:
+        assert not lx.is_strictly_diagonally_dominant(operator)
+
+    row_sum = (jnp.sum(jnp.abs(matrix), axis=0) + 0.1).astype(dtype)
+    strictly_diagonally_dominant = _setup(
+        getkey, matrix + jnp.diag(row_sum), lx.strictly_diagonally_dominant_tag
+    )
+
+    _assert_except_diag(
+        lx.is_strictly_diagonally_dominant,
+        strictly_diagonally_dominant,
+        flip_cond=False,
+    )
+
+
+@pytest.mark.parametrize("dtype", (jnp.float64, jnp.complex128))
 def test_tangent_as_matrix(dtype, getkey):
     def _list_setup(matrix):
         return list(_setup(getkey, matrix))

--- a/tests/test_solve.py
+++ b/tests/test_solve.py
@@ -165,6 +165,7 @@ def test_grad_vmap_symbolic_cotangent():
         lx.NormalCG(0.0, 0.0, max_steps=2),
         lx.BiCGStab(0.0, 0.0, max_steps=2),
         lx.GMRES(0.0, 0.0, max_steps=2),
+        lx.Jacobi(0.0, 0.0, max_steps=2),
     ),
 )
 def test_iterative_solver_max_steps_only(solver):

--- a/tests/test_solve.py
+++ b/tests/test_solve.py
@@ -166,6 +166,7 @@ def test_grad_vmap_symbolic_cotangent():
         lx.BiCGStab(0.0, 0.0, max_steps=2),
         lx.GMRES(0.0, 0.0, max_steps=2),
         lx.Jacobi(0.0, 0.0, max_steps=2),
+        lx.GaussSeidel(0.0, 0.0, max_steps=2),
     ),
 )
 def test_iterative_solver_max_steps_only(solver):

--- a/tests/test_well_posed.py
+++ b/tests/test_well_posed.py
@@ -33,6 +33,8 @@ from .helpers import (
 def test_small_wellposed(make_operator, solver, tags, ops, getkey, dtype):
     if jax.config.jax_enable_x64:  # pyright: ignore
         tol = 1e-10
+        if isinstance(solver, (lx.Jacobi, lx.GaussSeidel)):
+            tol = 1e-8
     else:
         tol = 1e-4
     (matrix,) = construct_matrix(getkey, solver, tags, dtype=dtype)

--- a/tests/test_well_posed.py
+++ b/tests/test_well_posed.py
@@ -55,7 +55,16 @@ def test_small_wellposed(make_operator, solver, tags, ops, getkey, dtype):
 def test_pytree_wellposed(solver, getkey, dtype):
     if not isinstance(
         solver,
-        (lx.Diagonal, lx.Triangular, lx.Tridiagonal, lx.Cholesky, lx.CG, lx.NormalCG),
+        (
+            lx.Diagonal,
+            lx.Triangular,
+            lx.Tridiagonal,
+            lx.Cholesky,
+            lx.CG,
+            lx.NormalCG,
+            lx.Jacobi,
+            lx.GaussSeidel,
+        ),
     ):
         if jax.config.jax_enable_x64:  # pyright: ignore
             tol = 1e-10

--- a/tests/test_well_posed.py
+++ b/tests/test_well_posed.py
@@ -33,8 +33,6 @@ from .helpers import (
 def test_small_wellposed(make_operator, solver, tags, ops, getkey, dtype):
     if jax.config.jax_enable_x64:  # pyright: ignore
         tol = 1e-10
-        if isinstance(solver, (lx.Jacobi, lx.GaussSeidel)):
-            tol = 1e-8
     else:
         tol = 1e-4
     (matrix,) = construct_matrix(getkey, solver, tags, dtype=dtype)


### PR DESCRIPTION
Hi @patrick-kidger,

This is to implement #116. I opened it as a draft because I wanted to get some feedback/have questions on handling Lineax internals and what features to add.

So far, I have implemented the `Jacobi` & `GaussSeidel` methods as a mixture of the dense solver (with their matrix materialization) and Krylov solvers (with their implementation of the iterative process). Moreover, I added a new tag `strictly_diagonally_dominant` because this is a sufficient (but not necessary) condition for their convergence (for [Jacobi](https://en.wikipedia.org/wiki/Jacobi_method#Convergence) and for [GaussSeidel](https://en.wikipedia.org/wiki/Gauss%E2%80%93Seidel_method#Convergence)). If `max_step=None`, the smoothers run for `100 * size` instead of `10 * size` (what the Krylov solvers default to) because of the slower convergence. I am thinking of bumping it to `200 * size` since I otherwise observe that sometimes some tests fail (due to the randomized matrices).

I have some questions to discuss before I polish up the PR with docs etc.:
1. Is my handling of the tag correctly? (with regards to `_operator.py` and `test_operator.py`) Do you think this new tag is a good addition? As far as I understand, Lineax does implement methods to *actually* check if operators obey their tags. It only relies on the user specification. (One could add a simple function to check if twice the absolute diagonal is larger than the absolute row sum.)
2. Are there additional tests for which I have to register the two new solvers?
3. I will implement the option for relaxation in both `Jacobi` and `GaussSeidel`. For the latter, this gives the [SOR method](https://en.wikipedia.org/wiki/Successive_over-relaxation). For symmetric matrices, there is also the [SSOR method](https://en.wikipedia.org/wiki/Symmetric_successive_over-relaxation). Do you think it is worth adding it as well?
4. Do you think that there should be some handling of the `strictly_diagonally_dominant` tag in the smoothing methods? Giving a warning, if it is not present? It is not a necessary condition, though.

These are the open points I will tackle after your feedback:

- [ ] Add Documentation
- [ ] Add a relaxation option to Jacobi and GaussSeidel and test it