### PR TITLE
Update guidelines for installation of doc dependencies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,7 @@ Make your changes. You can then build the documentation by doing
 pip install -e '.[docs]'
 mkdocs serve
 ```
-You can then see your local copy of the documentation in a web browser.
+You can then see your local copy of the documentation by navigating to `localhost:8000` in a web browser.
 
 ## Contributor License Agreement
 


### PR DESCRIPTION
The contribution guidelines were out of date since the doc stack update. 

This PR is expected to fail the CI, with the same things that fail in https://github.com/patrick-kidger/lineax/pull/176 and and https://github.com/patrick-kidger/lineax/pull/178.