### PR TITLE
Moved bool states to Static.

### DIFF
--- a/lineax/_operator.py
+++ b/lineax/_operator.py
@@ -255,7 +255,7 @@ class MatrixLinearOperator(AbstractLinearOperator):
             raise ValueError(
                 "`MatrixLinearOperator(matrix=...)` should be 2-dimensional."
             )
-        if not jnp.issubdtype(matrix, jnp.inexact):
+        if not jnp.issubdtype(matrix.dtype, jnp.inexact):
             matrix = matrix.astype(jnp.float32)
         self.matrix = matrix
         self.tags = _frozenset(tags)
@@ -397,7 +397,9 @@ class PyTreeLinearOperator(AbstractLinearOperator):
                     raise ValueError(
                         "`pytree` and `output_structure` are not consistent"
                     )
-                return jax.ShapeDtypeStruct(shape=shape[ndim:], dtype=jnp.dtype(leaf))
+                return jax.ShapeDtypeStruct(
+                    shape=shape[ndim:], dtype=jnp.result_type(leaf)
+                )
 
             return _Leaf(jtu.tree_map(sub_get_structure, subpytree))
 

--- a/lineax/_solver/qr.py
+++ b/lineax/_solver/qr.py
@@ -14,6 +14,7 @@
 
 from typing import Any, TypeAlias
 
+import equinox.internal as eqxi
 import jax.numpy as jnp
 import jax.scipy as jsp
 from jaxtyping import Array, PyTree
@@ -29,7 +30,7 @@ from .misc import (
 )
 
 
-_QRState: TypeAlias = tuple[tuple[Array, Array], bool, PackedStructures]
+_QRState: TypeAlias = tuple[tuple[Array, Array], eqxi.Static, PackedStructures]
 
 
 class QR(AbstractLinearSolver):
@@ -59,7 +60,7 @@ class QR(AbstractLinearSolver):
             matrix = matrix.T
         qr = jnp.linalg.qr(matrix, mode="reduced")  # pyright: ignore
         packed_structures = pack_structures(operator)
-        return qr, transpose, packed_structures
+        return qr, eqxi.Static(transpose), packed_structures
 
     def compute(
         self,
@@ -68,6 +69,7 @@ class QR(AbstractLinearSolver):
         options: dict[str, Any],
     ) -> tuple[PyTree[Array], RESULTS, dict[str, Any]]:
         (q, r), transpose, packed_structures = state
+        transpose = transpose.value
         del state, options
         vector = ravel_vector(vector, packed_structures)
         if transpose:
@@ -86,7 +88,11 @@ class QR(AbstractLinearSolver):
     def transpose(self, state: _QRState, options: dict[str, Any]):
         (q, r), transpose, structures = state
         transposed_packed_structures = transpose_packed_structures(structures)
-        transpose_state = (q, r), not transpose, transposed_packed_structures
+        transpose_state = (
+            (q, r),
+            eqxi.Static(not transpose.value),
+            transposed_packed_structures,
+        )
         transpose_options = {}
         return transpose_state, transpose_options
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,18 +67,18 @@ addopts = "--jaxtyping-packages=lineax,beartype.beartype(conf=beartype.BeartypeC
 extend-include = ["*.ipynb"]
 src = []
 
-[tool.ruff.isort]
-combine-as-imports = true
-extra-standard-library = ["typing_extensions"]
-lines-after-imports = 2
-order-by-type = false
-
 [tool.ruff.lint]
 fixable = ["I001", "F401", "UP"]
-ignore = ["E402", "E721", "E731", "E741", "F722", "UP038"]
+ignore = ["E402", "E721", "E731", "E741", "F722"]
 select = ["E", "F", "I001", "UP"]
 
 [tool.ruff.lint.flake8-import-conventions.extend-aliases]
 "collections" = "co"
 "functools" = "ft"
 "itertools" = "it"
+
+[tool.ruff.lint.isort]
+combine-as-imports = true
+extra-standard-library = ["typing_extensions"]
+lines-after-imports = 2
+order-by-type = false

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -26,4 +26,6 @@ for file in here.iterdir():
     if file.is_file() and file.name.startswith("test"):
         out = subprocess.run(f"pytest {file}", shell=True).returncode
         running_out = max(running_out, out)
+        if out != 0:
+            break
 sys.exit(running_out)


### PR DESCRIPTION
There look to be some downstream failures otherwise, in places where we're silently assuming that the state is entirely dynamic, e.g. where VeryChord tracks the state.

This looks to be the easiest solution – to just make the whole state dynamic.

NB we don't have this happen automatically inside `linear_solve` because `.init` is a public API that may be called independently, and its state passed into `linear_solve`. (For the case of re-using one operator.)