### PR TITLE
Fix NormalCG shape bug with rectangular matrices

### DIFF
--- a/tests/test_singular.py
+++ b/tests/test_singular.py
@@ -107,6 +107,7 @@ def test_gmres_stagnation_or_breakdown(getkey, dtype):
         lx.QR(),
         lx.SVD(),
         lx.LSMR(atol=tol, rtol=tol),
+        lx.NormalCG(rtol=tol, atol=tol),
     ),
 )
 def test_nonsquare_pytree_operator1(solver):
@@ -128,6 +129,7 @@ def test_nonsquare_pytree_operator1(solver):
         lx.QR(),
         lx.SVD(),
         lx.LSMR(atol=tol, rtol=tol),
+        lx.NormalCG(rtol=tol, atol=tol),
     ),
 )
 def test_nonsquare_pytree_operator2(solver):


### PR DESCRIPTION
The bug was introduced in commit 6893255 which moved the preconditioner_and_y0() call before the vector transformation for NormalCG mode. This caused y0 to be initialized in the wrong space. This was not caught previously because NormalCG was omitted from rectangular matrix tests! I realise this is fixed on `dev` with super clean and awesome `lx.Normal` implementation! ❤️ But this provides a temporary fix on `main` until `dev` is merged in, these changes can be ignored at that point.

For rectangular matrices (m×n where m>n), NormalCG transforms the vector from output space (m,) to input space (n,) via A^T. The y0 initial guess must be in this transformed space, but was being initialized before the transformation.

This fix:
- Moves preconditioner_and_y0() to after vector transformation
- Preserves the preconditioner transformation logic added in 6893255
- Ensures y0 has the correct shape for both square and rectangular matrices
- Adds NormalCG to rectangular matrix tests to prevent regression

Fixes issue with NormalCG failing on overdetermined systems with: `TypeError: dot_general requires contracting dimensions to have the same shape, got (3,) and (6,).`