### PR TITLE
Add backwards compatibility for NormalCG and add deprecation warning

### DIFF
--- a/lineax/_solver/cg.py
+++ b/lineax/_solver/cg.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import warnings
 from collections.abc import Callable
 from typing import Any, TypeAlias
-import warnings
 
 import equinox.internal as eqxi
 import jax


### PR DESCRIPTION
Thought I'd try get this in in light of the upcoming release, I find that `lx.NormalCG(rtol=..., atol=...)` no longer works as our helper function only accepts positional arguments.

Super looking forward to the new release, it will greatly clean up a `ProjectionOperator` I've been using that uses a linear solver internally that I had to special case to tell square solves to solve normal equations instead. Thanks for all the great work everyone's put in, especially on LSMR! Do we have a special way of testing whether a solver can handle rectangular matrices?

Will also try to brush of my other PR's today if there's still time for that.