### PR TITLE
materialise Normal(Cholesky()) inner solver

### DIFF
--- a/lineax/_solver/normal.py
+++ b/lineax/_solver/normal.py
@@ -107,8 +107,8 @@ class Normal(
         # Cholesky materialises op twice when computing (op^H @ op).as_matrix()
         # Cheaper to materialise first and then conjugate-transpose.
         # For iterative solvers we only linearise to avoid eager materialisation.
-        _materialise = isinstance(self.inner_solver, Cholesky)
-        lin_op = materialise(operator) if _materialise else linearise(operator)
+        is_cholesky = isinstance(self.inner_solver, Cholesky)
+        lin_op = materialise(operator) if is_cholesky else linearise(operator)
         if tall:
             inner_operator = conj(lin_op.transpose()) @ lin_op
         else:


### PR DESCRIPTION
Follow-up to #198, I'm not enough of an XLA guru to work out how to get XLA to optimise for us, so just special-casing for now under the assumption there is no good reason to use any other solver. I had to create the `is_cholesky` variable because pyright didn't like a direct `isinstance` check.