### PR TITLE
Modify existing QR solver to support pivoted QR

### DIFF
--- a/lineax/_solver/qr.py
+++ b/lineax/_solver/qr.py
@@ -15,10 +15,12 @@
 from typing import Any, TypeAlias
 
 import equinox.internal as eqxi
+import jax
 import jax.numpy as jnp
 import jax.scipy as jsp
 from jaxtyping import Array, PyTree
 
+from .._misc import resolve_rcond
 from .._solution import RESULTS
 from .._solve import AbstractLinearSolver
 from .misc import (
@@ -30,7 +32,72 @@ from .misc import (
 )
 
 
-_QRState: TypeAlias = tuple[tuple[Array, Array], eqxi.Static, PackedStructures]
+_QRState: TypeAlias = tuple[
+    tuple[Array, Array] | tuple[Array, Array, Array], eqxi.Static, PackedStructures
+]
+
+
+def _rank_mask(q, r, rcond):
+    """Return (diag_r, is_valid, is_full_rank) for a pivoted QR factor."""
+    m, *_ = q.shape
+    k, *_ = r.shape
+    tol = resolve_rcond(rcond, k, m, r.dtype) * jnp.abs(r[0, 0])
+    diag_r = jnp.diag(r)
+    is_valid = jnp.abs(diag_r) > jnp.asarray(tol)
+    return diag_r, is_valid, jnp.all(is_valid)
+
+
+def _compute_pivoted(q, r, jpvt, vector, rcond):
+    diag_r, is_valid, is_full_rank = _rank_mask(q, r, rcond)
+    k, *_ = r.shape
+    c = q.T.conj() @ vector
+    inv_perm = jnp.argsort(jpvt)
+
+    def _full_rank(_):
+        y = jsp.linalg.solve_triangular(r, c, unit_diagonal=False)
+        return y[inv_perm]
+
+    def _rank_deficient(_):
+        null_cols = ~is_valid
+        diag_idx = jnp.arange(k)
+        r_safe = r.at[diag_idx, diag_idx].set(
+            jnp.where(is_valid, diag_r, jnp.ones(k, dtype=r.dtype))
+        )
+        c_masked = c * is_valid.astype(r.dtype)
+        R_valid = r * is_valid[:, None].astype(r.dtype)
+        R_null = R_valid * null_cols[None, :].astype(r.dtype)
+
+        combined = jnp.concatenate([jnp.expand_dims(c_masked, axis=1), R_null], axis=1)
+        sol = jsp.linalg.solve_triangular(r_safe, combined, unit_diagonal=False)
+        w = sol[:, 0]
+        F = sol[:, 1:]
+
+        G = jnp.eye(k, dtype=r.dtype) + F.T.conj() @ F
+        c_chol, lower = jsp.linalg.cho_factor(G)
+        z = jsp.linalg.cho_solve((c_chol, lower), F.T.conj() @ w)
+        y = w - F @ z + z
+        return y[inv_perm]
+
+    return jax.lax.cond(is_full_rank, _full_rank, _rank_deficient, None)
+
+
+def _compute_pivoted_transpose(q, r, jpvt, vector, rcond):
+    _, is_valid, is_full_rank = _rank_mask(q, r, rcond)
+    c_perm = vector[jpvt]
+
+    def _full_rank(_):
+        v = jsp.linalg.solve_triangular(r, c_perm, trans="T", unit_diagonal=False)
+        return q.conj() @ v
+
+    def _rank_deficient(_):
+        R_valid = r * is_valid[:, None].astype(r.dtype)
+        G = R_valid.conj() @ R_valid.T + jnp.diag((~is_valid).astype(r.dtype))
+        rhs = R_valid.conj() @ c_perm
+        c_chol, lower = jsp.linalg.cho_factor(G)
+        v = jsp.linalg.cho_solve((c_chol, lower), rhs)
+        return q.conj() @ v
+
+    return jax.lax.cond(is_full_rank, _full_rank, _rank_deficient, None)
 
 
 class QR(AbstractLinearSolver):
@@ -42,14 +109,14 @@ class QR(AbstractLinearSolver):
 
     !!! info
 
-        Note that whilst this does handle non-square operators, it still can only
-        handle full-rank operators.
+        When `pivoting=False` (the default), this solver can only handle full-rank
+        operators. For rank-deficient operators, use `pivoting=True` or switch to
+        [`lineax.SVD`][] instead.
 
-        This is because JAX does not currently support a rank-revealing/pivoted QR
-        decomposition, see [issue #12897](https://github.com/google/jax/issues/12897).
-
-        For such use cases, switch to [`lineax.SVD`][] instead.
     """
+
+    pivoting: bool = False
+    rcond: float | None = None
 
     def init(self, operator, options):
         del options
@@ -58,7 +125,7 @@ class QR(AbstractLinearSolver):
         transpose = n > m
         if transpose:
             matrix = matrix.T
-        qr = jnp.linalg.qr(matrix, mode="reduced")  # pyright: ignore
+        qr = jsp.linalg.qr(matrix, mode="economic", pivoting=self.pivoting)
         packed_structures = pack_structures(operator)
         return qr, eqxi.Static(transpose), packed_structures
 
@@ -68,28 +135,35 @@ class QR(AbstractLinearSolver):
         vector: PyTree[Array],
         options: dict[str, Any],
     ) -> tuple[PyTree[Array], RESULTS, dict[str, Any]]:
-        (q, r), transpose, packed_structures = state
+        (q, r, *p), transpose, packed_structures = state
         transpose = transpose.value
         del state, options
         vector = ravel_vector(vector, packed_structures)
         if transpose:
-            # Minimal norm solution if underdetermined.
-            solution = q.conj() @ jsp.linalg.solve_triangular(
-                r, vector, trans="T", unit_diagonal=False
-            )
+            if self.pivoting:
+                solution = _compute_pivoted_transpose(q, r, p[0], vector, self.rcond)
+            else:
+                solution = q.conj() @ jsp.linalg.solve_triangular(
+                    r,
+                    vector,
+                    trans="T",
+                    unit_diagonal=False,
+                )
         else:
-            # Least squares solution if overdetermined.
-            solution = jsp.linalg.solve_triangular(
-                r, q.T.conj() @ vector, trans="N", unit_diagonal=False
-            )
+            if self.pivoting:
+                solution = _compute_pivoted(q, r, p[0], vector, self.rcond)
+            else:
+                solution = jsp.linalg.solve_triangular(
+                    r, q.T.conj() @ vector, trans="N", unit_diagonal=False
+                )
         solution = unravel_solution(solution, packed_structures)
         return solution, RESULTS.successful, {}
 
     def transpose(self, state: _QRState, options: dict[str, Any]):
-        (q, r), transpose, structures = state
+        (q, r, *p), transpose, structures = state
         transposed_packed_structures = transpose_packed_structures(structures)
         transpose_state = (
-            (q, r),
+            (q, r, *p),
             eqxi.Static(not transpose.value),
             transposed_packed_structures,
         )
@@ -97,9 +171,9 @@ class QR(AbstractLinearSolver):
         return transpose_state, transpose_options
 
     def conj(self, state: _QRState, options: dict[str, Any]):
-        (q, r), transpose, structures = state
+        (q, r, *p), transpose, structures = state
         conj_state = (
-            (q.conj(), r.conj()),
+            (q.conj(), r.conj(), *p),
             transpose,
             structures,
         )
@@ -107,10 +181,16 @@ class QR(AbstractLinearSolver):
         return conj_state, conj_options
 
     def assume_full_rank(self):
-        return True
+        return not self.pivoting
 
 
 QR.__init__.__doc__ = """**Arguments:**
 
-Nothing.
+- `pivoting`: If `True`, use column-pivoted QR decomposition for improved numerical
+    stability. The pivoted decomposition satisfies `A[:, P] = Q R` where the diagonal
+    of `R` is non-increasing. Defaults to `False`.
+- `rcond`: the cutoff for determining numerical rank when `pivoting=True`. Diagonal
+    entries of `R` smaller than `rcond * |R[0, 0]|` are treated as zero. Defaults to
+    machine precision times `max(N, M)`, where `(N, M)` is the shape of the operator.
+    Ignored when `pivoting=False`.
 """

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -108,6 +108,7 @@ solvers_tags_pseudoinverse = [
     (lx.Tridiagonal(), lx.tridiagonal_tag, False),
     (lx.LU(), (), False),
     (lx.QR(), (), False),
+    (lx.QR(pivoting=True), (), True),
     (lx.SVD(), (), True),
     (lx.BiCGStab(rtol=tol, atol=tol), (), False),
     (lx.GMRES(rtol=tol, atol=tol), (), False),

--- a/tests/test_singular.py
+++ b/tests/test_singular.py
@@ -104,6 +104,7 @@ def test_gmres_stagnation_or_breakdown(getkey, dtype):
     (
         lx.AutoLinearSolver(well_posed=None),
         lx.QR(),
+        lx.QR(pivoting=True),
         lx.SVD(),
         lx.LSMR(atol=tol, rtol=tol),
         lx.Normal(lx.Cholesky()),
@@ -127,6 +128,7 @@ def test_nonsquare_pytree_operator1(solver):
     (
         lx.AutoLinearSolver(well_posed=None),
         lx.QR(),
+        lx.QR(pivoting=True),
         lx.SVD(),
         lx.LSMR(atol=tol, rtol=tol),
         lx.Normal(lx.Cholesky()),
@@ -150,6 +152,7 @@ def test_nonsquare_pytree_operator2(solver):
     (
         lx.AutoLinearSolver(well_posed=None),
         lx.QR(),
+        lx.QR(pivoting=True),
         lx.SVD(),
         lx.Normal(lx.Cholesky()),
         lx.Normal(lx.SVD()),
@@ -201,6 +204,7 @@ def test_nonsquare_mat_vec(solver, full_rank, jvp, wide, dtype, getkey):
     (
         lx.AutoLinearSolver(well_posed=None),
         lx.QR(),
+        lx.QR(pivoting=True),
         lx.SVD(),
         lx.Normal(lx.Cholesky()),
         lx.Normal(lx.SVD()),

--- a/tests/test_solve.py
+++ b/tests/test_solve.py
@@ -61,7 +61,7 @@ def test_nontrivial_diagonal_operator():
     assert tree_allclose(out, true_out)
 
 
-@pytest.mark.parametrize("solver", (lx.LU(), lx.QR(), lx.SVD()))
+@pytest.mark.parametrize("solver", (lx.LU(), lx.QR(), lx.QR(pivoting=True), lx.SVD()))
 def test_mixed_dtypes(solver):
     f32 = lambda x: jnp.array(x, dtype=jnp.float32)
     f64 = lambda x: jnp.array(x, dtype=jnp.float64)
@@ -74,7 +74,7 @@ def test_mixed_dtypes(solver):
     assert tree_allclose(out, true_out)
 
 
-@pytest.mark.parametrize("solver", (lx.LU(), lx.QR(), lx.SVD()))
+@pytest.mark.parametrize("solver", (lx.LU(), lx.QR(), lx.QR(pivoting=True), lx.SVD()))
 def test_mixed_dtypes_complex(solver):
     c64 = lambda x: jnp.array(x, dtype=jnp.complex64)
     c128 = lambda x: jnp.array(x, dtype=jnp.complex128)
@@ -87,7 +87,7 @@ def test_mixed_dtypes_complex(solver):
     assert tree_allclose(out, true_out)
 
 
-@pytest.mark.parametrize("solver", (lx.LU(), lx.QR(), lx.SVD()))
+@pytest.mark.parametrize("solver", (lx.LU(), lx.QR(), lx.QR(pivoting=True), lx.SVD()))
 def test_mixed_dtypes_complex_real(solver):
     f64 = lambda x: jnp.array(x, dtype=jnp.float64)
     c128 = lambda x: jnp.array(x, dtype=jnp.complex128)


### PR DESCRIPTION
Adds column-pivoted QR as a faster alternative to `SVD` for rank-deficient and near-singular operators #141 #201.

New parameters on `QR`:
- `pivoting: bool = False` enables column-pivoted decomposition satisfying `A[:, P] = QR`
- `rcond: float | None = None` rank cutoff threshold (defaults to machine precision * `max(N, M)`)

When `pivoting=True`, the solver detects numerical rank from the diagonal of `R` and dispatches via `lax.cond` between a fast full-rank path (plain back-substitution) and a minimum-norm rank-deficient path (null-space correction via a small Cholesky solve). `assume_full_rank()` returns `False` when pivoting.