### PR TITLE
Add pivoted qr solver

### DIFF
--- a/docs/api/solvers.md
+++ b/docs/api/solvers.md
@@ -35,7 +35,10 @@ These are capable of solving ill-posed linear problems.
         members:
             - __init__
 
----
+::: lineax.QRP
+    options:
+        members:
+            - __init__
 
 ::: lineax.SVD
     options:

--- a/lineax/__init__.py
+++ b/lineax/__init__.py
@@ -62,6 +62,7 @@ from ._solver import (
     Normal as Normal,
     NormalCG as NormalCG,
     QR as QR,
+    QRP as QRP,
     SVD as SVD,
     Triangular as Triangular,
     Tridiagonal as Tridiagonal,

--- a/lineax/_solve.py
+++ b/lineax/_solve.py
@@ -767,10 +767,11 @@ def linear_solve(
             stats={},
         )
     if state == sentinel:
-        state = solver.init(operator, options)
-        dynamic_state, static_state = eqx.partition(state, eqx.is_array)
-        dynamic_state = lax.stop_gradient(dynamic_state)
-        state = eqx.combine(dynamic_state, static_state)
+        dynamic_operator, static_operator = eqx.partition(operator, eqx.is_array)
+        stopped_operator = eqx.combine(
+            lax.stop_gradient(dynamic_operator), static_operator
+        )
+        state = solver.init(stopped_operator, options)
 
     state = eqxi.nondifferentiable(state, name="`lineax.linear_solve(..., state=...)`")
     options = eqxi.nondifferentiable(

--- a/lineax/_solver/__init__.py
+++ b/lineax/_solver/__init__.py
@@ -20,6 +20,7 @@ from .gmres import GMRES as GMRES
 from .lsmr import LSMR as LSMR
 from .lu import LU as LU
 from .normal import Normal as Normal
+from .pivotedqr import QRP as QRP
 from .qr import QR as QR
 from .svd import SVD as SVD
 from .triangular import Triangular as Triangular

--- a/lineax/_solver/pivotedqr.py
+++ b/lineax/_solver/pivotedqr.py
@@ -1,0 +1,242 @@
+# Copyright 2023 Google LLC
+
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any, TypeAlias
+
+import equinox as eqx
+import equinox.internal as eqxi
+import jax.numpy as jnp
+import jax.scipy as jsp
+from jaxtyping import Array, PyTree
+
+from .._misc import resolve_rcond
+from .._solution import RESULTS
+from .._solve import AbstractLinearSolver
+from .misc import (
+    pack_structures,
+    PackedStructures,
+    ravel_vector,
+    transpose_packed_structures,
+    unravel_solution,
+)
+
+
+_QRPState: TypeAlias = tuple[
+    tuple[Array, Array, Array, Array] | tuple[Array, Array, Array],
+    eqxi.Static,
+    PackedStructures,
+]
+
+
+class QRP(AbstractLinearSolver):
+    """QR with column pivoting solver for linear systems.
+
+    This solver can handle arbitrary operators, including non-square and rank
+    deficient ones. In this case it will return the pseudoinverse solution to
+    the linear system.
+
+    The solver operates by default in a mode where the rank is determined
+    dynamically. In order to make jax transformations possible, the computation
+    s structured in such a way as to work simultaneously for all possible
+    ranks, but this comes at a cost. In order to preserve efficiency under
+    jax's model, this solver optionally allows the user to provide the rank of
+    the operator statically, through the `rank_defect` parameter. In static
+    rank mode and if `rcond` is provided, guaranteed errors are emitted if
+    the actual rank is different than the statically asserted rank.
+
+    """
+
+    rank_defect: int | None = None
+    rcond: float | None = None
+
+    def init(self, operator, options):
+        del options
+        packed_structures = pack_structures(operator)
+        matrix = operator.as_matrix()
+        m, n = matrix.shape
+        transpose = n > m
+        if transpose:
+            matrix = matrix.T
+        q, r, p = jsp.linalg.qr(matrix, mode="economic", pivoting=True)
+        if self.rank_defect is not None:
+            if self.rcond is not None and r.size > 0:
+                r = eqx.error_if(
+                    r,
+                    (jnp.abs(r.diagonal()) < self.rcond * jnp.abs(r[0, 0])).sum()
+                    != self.rank_defect,
+                    "QRP: rcond and rank_defect both provided and operator is not "
+                    "the asserted rank",
+                )
+            if self.rank_defect > 0:
+                r = r[: -self.rank_defect]
+                q = q[:, : -self.rank_defect]
+        else:
+            rcond = resolve_rcond(self.rcond, n, m, r.dtype)
+            rcond = jnp.array(rcond, dtype=r.real.dtype)
+            if r.size > 0:
+                rcond = rcond * jnp.abs(r[0, 0])
+            mask = jnp.abs(r.diagonal()) > rcond
+            r = jnp.where(mask[:, None], r, 0.0)
+        if self.rank_defect == 0:
+            return (q, r, p), eqxi.Static(transpose), packed_structures
+        else:
+            # Complete orthogonal factorization case (see lapack sgelsy
+            # documentation)
+
+            # In this case we must eliminate to the right of the r x r triangle
+            # with orthogonal transformations on columns. jax currently doesn't
+            # expose the trapezoidal orthogonal elimination (eg lapack stzrzf,
+            # needed for the implementation of sgelsy). We work around this by
+            # not exploiting the upper trapezoidal property and instead doing a
+            # second unpivoted qr.
+
+            # In the dynamic rank case, we are forced to work at the same time
+            # on here on the negligible bottom part of r, but this does not
+            # interfere with the result of the top part since we are doing
+            # column operations and the bottom is assumed negligible.
+            z, t = jnp.linalg.qr(r.T, mode="reduced")
+            t = t.T
+            z = z.T
+            return (q, t, z, p), eqxi.Static(transpose), packed_structures
+
+    def compute(
+        self,
+        state: _QRPState,
+        vector: PyTree[Array],
+        options: dict[str, Any],
+    ) -> tuple[PyTree[Array], RESULTS, dict[str, Any]]:
+        factorization, transpose, packed_structures = state
+        transpose = transpose.value
+        del state, options
+        vector = ravel_vector(vector, packed_structures)
+        info = {}
+
+        if self.rank_defect == 0:
+            q, r, p = factorization  # pyright: ignore
+            if transpose:
+                # Minimal norm solution if underdetermined.
+                solution = q.conj() @ jsp.linalg.solve_triangular(
+                    r, vector[p], trans="T", unit_diagonal=False
+                )
+            else:
+                # Least squares solution if overdetermined.
+                solution = jsp.linalg.solve_triangular(
+                    r, q.T.conj() @ vector, trans="N", unit_diagonal=False
+                )
+                solution = solution.at[p].set(solution)
+        else:
+            # complete orthogonal factorization case
+            q, t, z, p = factorization  # pyright: ignore
+            if self.rank_defect is not None:
+                if transpose:
+                    solution = q.conj() @ jsp.linalg.solve_triangular(
+                        t,
+                        z.conj() @ vector[p],
+                        trans="T",
+                        unit_diagonal=False,
+                        lower=True,
+                    )
+                else:
+                    solution = z.T.conj() @ jsp.linalg.solve_triangular(
+                        t,
+                        q.T.conj() @ vector,
+                        trans="N",
+                        unit_diagonal=False,
+                        lower=True,
+                    )
+                    solution = solution.at[p].set(solution)
+            else:
+                mask = jnp.abs(t.diagonal()) > 0.0
+                rank = mask.sum()
+                info["rank"] = rank
+
+                # Avoid the creation of NaN and inf in values which will
+                # later be discarded
+                t += jnp.diag(jnp.where(mask, 0.0, 1.0))
+
+                if transpose:
+                    solution = q.conj() @ jnp.where(
+                        mask,
+                        jsp.linalg.solve_triangular(
+                            t,
+                            z.conj() @ vector[p],
+                            trans="T",
+                            unit_diagonal=False,
+                            lower=True,
+                        ),
+                        0,
+                    )
+                else:
+                    solution = z.T.conj() @ jnp.where(
+                        mask,
+                        jsp.linalg.solve_triangular(
+                            t,
+                            q.T.conj() @ vector,
+                            trans="N",
+                            unit_diagonal=False,
+                            lower=True,
+                        ),
+                        0,
+                    )
+                    solution = solution.at[p].set(solution)
+
+        solution = unravel_solution(solution, packed_structures)
+        return solution, RESULTS.successful, info
+
+    def transpose(self, state: _QRPState, options: dict[str, Any]):
+        factorization, transpose, structures = state
+        transposed_packed_structures = transpose_packed_structures(structures)
+        transpose_state = (
+            factorization,
+            eqxi.Static(not transpose.value),
+            transposed_packed_structures,
+        )
+        transpose_options = {}
+        return transpose_state, transpose_options
+
+    def conj(self, state: _QRPState, options: dict[str, Any]):
+        factorization, transpose, structures = state
+        conj_factorization = tuple(f.conj() for f in factorization[:-1]) + (
+            factorization[-1],
+        )
+        conj_state = (
+            conj_factorization,
+            transpose,
+            structures,
+        )
+        conj_options = {}
+        return conj_state, conj_options
+
+    def assume_full_rank(self):
+        return self.rank_defect == 0
+
+
+QRP.__init__.__doc__ = """**Arguments:**
+
+- `rank_defect`: If set, the rank of the operator is statically assumed to be
+  `min(N,M) - rank_defect`, where `(N,M)` is the shape of the operator.
+ 
+    If not set, the solver is in dynamic rank mode.
+
+- `rcond`: The threshold for determining rank. Matrices will be
+    considered to have rank at most $r$ roughly when the ratio of the $r+1$st
+    and first singular values is at most `rcond`.
+
+    In dynamic rank mode (see `rank_defect`), `rcond` defaults to machine
+    precision times `max(N, M)`, where `(N, M)` is the shape of the operator.
+
+    In static rank mode and if `rcond` is provided, an error will be emitted if
+    the dynamically determined rank doesn't match the statically asserted rank.
+"""

--- a/lineax/_solver/qr.py
+++ b/lineax/_solver/qr.py
@@ -45,10 +45,8 @@ class QR(AbstractLinearSolver):
         Note that whilst this does handle non-square operators, it still can only
         handle full-rank operators.
 
-        This is because JAX does not currently support a rank-revealing/pivoted QR
-        decomposition, see [issue #12897](https://github.com/google/jax/issues/12897).
-
-        For such use cases, switch to [`lineax.SVD`][] instead.
+        For solving rank deficient linear least squares, use [`lineax.QRP`][] or
+        [`lineax.SVD`][] instead.
     """
 
     def init(self, operator, options):

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -366,10 +366,9 @@ def jvp_jvp_impl(
         if use_state:
 
             def linear_solve1(operator, vector):
-                state = solver.init(operator, options={})
-                state_dynamic, state_static = eqx.partition(state, eqx.is_inexact_array)
-                state_dynamic = lax.stop_gradient(state_dynamic)
-                state = eqx.combine(state_dynamic, state_static)
+                op_dynamic, op_static = eqx.partition(operator, eqx.is_inexact_array)
+                stopped_operator = eqx.combine(lax.stop_gradient(op_dynamic), op_static)
+                state = solver.init(stopped_operator, options={})
 
                 sol = lx.linear_solve(operator, vector, state=state, solver=solver)
                 return sol.value

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -69,18 +69,24 @@ def construct_matrix(getkey, solver, tags, num=1, *, size=3, dtype=jnp.float64):
     )
 
 
-def construct_singular_matrix(getkey, solver, tags, num=1, dtype=jnp.float64):
-    matrices = construct_matrix(getkey, solver, tags, num, dtype=dtype)
+def construct_singular_matrix(
+    getkey, solver, tags, num=1, *, size=3, dtype=jnp.float64
+):
+    # There is currently no attempt to generate matrices respecting tags.
+    matrices = construct_matrix(getkey, solver, tags, num, size=3, dtype=dtype)
     if isinstance(solver, (lx.Diagonal, lx.CG, lx.BiCGStab, lx.GMRES)):
         return tuple(matrix.at[0, :].set(0) for matrix in matrices)
     else:
         version = jr.choice(getkey(), np.array([0, 1, 2]))
+        # version = jr.choice(getkey(), np.array([0, 1, 2, 3]))
         if version == 0:
+            return tuple(matrix.at[1:, 1:].set(0) for matrix in matrices)
+        if version == 1:
             return tuple(matrix.at[0, :].set(0) for matrix in matrices)
-        elif version == 1:
-            return tuple(matrix[1:, :] for matrix in matrices)
+        elif version == 2:
+            return tuple(matrix.at[:, 0].set(0) for matrix in matrices)
         else:
-            return tuple(matrix[:, 1:] for matrix in matrices)
+            return tuple(matrix - matrix.T for matrix in matrices)
 
 
 def construct_poisson_matrix(size, dtype=jnp.float64):
@@ -99,6 +105,7 @@ else:
 solvers_tags_pseudoinverse = [
     (lx.AutoLinearSolver(well_posed=True), (), False),
     (lx.AutoLinearSolver(well_posed=False), (), True),
+    (lx.AutoLinearSolver(well_posed=False), (), True),
     (lx.Triangular(), lx.lower_triangular_tag, False),
     (lx.Triangular(), lx.upper_triangular_tag, False),
     (lx.Triangular(), (lx.lower_triangular_tag, lx.unit_diagonal_tag), False),
@@ -108,19 +115,25 @@ solvers_tags_pseudoinverse = [
     (lx.Tridiagonal(), lx.tridiagonal_tag, False),
     (lx.LU(), (), False),
     (lx.QR(), (), False),
+    (lx.QRP(), (), False),
+    (lx.QRP(), (), True),
+    (lx.QRP(rank_defect=0), (), False),
+    (lx.QRP(rank_defect=1), (), True),
+    (lx.SVD(), (), False),
     (lx.SVD(), (), True),
     (lx.BiCGStab(rtol=tol, atol=tol), (), False),
     (lx.GMRES(rtol=tol, atol=tol), (), False),
     (lx.CG(rtol=tol, atol=tol), lx.positive_semidefinite_tag, False),
     (lx.CG(rtol=tol, atol=tol), lx.negative_semidefinite_tag, False),
     (lx.Normal(lx.CG(rtol=tol, atol=tol)), (), False),
+    (lx.LSMR(atol=tol, rtol=tol), (), False),
     (lx.LSMR(atol=tol, rtol=tol), (), True),
     (lx.Cholesky(), lx.positive_semidefinite_tag, False),
     (lx.Cholesky(), lx.negative_semidefinite_tag, False),
     (lx.Normal(lx.Cholesky()), (), False),
 ]
 solvers_tags = [(a, b) for a, b, _ in solvers_tags_pseudoinverse]
-solvers = [a for a, _, _ in solvers_tags_pseudoinverse]
+solvers = [a for a, _, c in solvers_tags_pseudoinverse if not c]
 pseudosolvers_tags = [(a, b) for a, b, c in solvers_tags_pseudoinverse if c]
 
 
@@ -139,10 +152,10 @@ def _materialise(operator, matrix):
 ops = (lambda x, y: (x, y), _transpose, _linearise, _materialise)
 
 
-def params(only_pseudo):
+def params(pseudo):
     for make_operator in make_operators:
         for solver, tags, pseudoinverse in solvers_tags_pseudoinverse:
-            if only_pseudo and not pseudoinverse:
+            if pseudo != pseudoinverse:
                 continue
             if (
                 make_operator is make_trivial_diagonal_operator
@@ -341,171 +354,151 @@ def jvp_jvp_impl(
     getkey, solver, tags, pseudoinverse, make_operator, use_state, make_matrix, dtype
 ):
     t_tags = (None,) * len(tags) if isinstance(tags, tuple) else None
-    if (make_matrix is construct_matrix) or pseudoinverse:
-        matrix, t_matrix, tt_matrix, tt_t_matrix = construct_matrix(
-            getkey, solver, tags, num=4, dtype=dtype
-        )
+    matrix, t_matrix, tt_matrix, tt_t_matrix = make_matrix(
+        getkey, solver, tags, num=4, dtype=dtype
+    )
 
-        make_op = ft.partial(make_operator, getkey)
-        t_make_operator = lambda p, t_p: eqx.filter_jvp(
-            make_op, (p, tags), (t_p, t_tags)
-        )
-        tt_make_operator = lambda p, t_p, tt_p, tt_t_p: eqx.filter_jvp(
-            t_make_operator, (p, t_p), (tt_p, tt_t_p)
-        )
-        (operator, t_operator), (tt_operator, tt_t_operator) = tt_make_operator(
-            matrix, t_matrix, tt_matrix, tt_t_matrix
-        )
+    make_op = ft.partial(make_operator, getkey)
+    t_make_operator = lambda p, t_p: eqx.filter_jvp(make_op, (p, tags), (t_p, t_tags))
+    tt_make_operator = lambda p, t_p, tt_p, tt_t_p: eqx.filter_jvp(
+        t_make_operator, (p, t_p), (tt_p, tt_t_p)
+    )
+    (operator, t_operator), (tt_operator, tt_t_operator) = tt_make_operator(
+        matrix, t_matrix, tt_matrix, tt_t_matrix
+    )
 
-        out_size, _ = matrix.shape
-        vec = jr.normal(getkey(), (out_size,), dtype=dtype)
-        t_vec = jr.normal(getkey(), (out_size,), dtype=dtype)
-        tt_vec = jr.normal(getkey(), (out_size,), dtype=dtype)
-        tt_t_vec = jr.normal(getkey(), (out_size,), dtype=dtype)
+    out_size, _ = matrix.shape
+    vec = jr.normal(getkey(), (out_size,), dtype=dtype)
+    t_vec = jr.normal(getkey(), (out_size,), dtype=dtype)
+    tt_vec = jr.normal(getkey(), (out_size,), dtype=dtype)
+    tt_t_vec = jr.normal(getkey(), (out_size,), dtype=dtype)
 
-        if use_state:
+    if use_state:
 
-            def linear_solve1(operator, vector):
-                op_dynamic, op_static = eqx.partition(operator, eqx.is_inexact_array)
-                stopped_operator = eqx.combine(lax.stop_gradient(op_dynamic), op_static)
-                state = solver.init(stopped_operator, options={})
+        def linear_solve1(operator, vector):
+            # state = solver.init(operator, options={})
+            # state_dynamic, state_static = eqx.partition(state, eqx.is_inexact_array)
+            # state_dynamic = lax.stop_gradient(state_dynamic)
+            # state = eqx.combine(state_dynamic, state_static)
+            op_dynamic, op_static = eqx.partition(operator, eqx.is_inexact_array)
+            stopped_operator = eqx.combine(lax.stop_gradient(op_dynamic), op_static)
+            state = solver.init(stopped_operator, options={})
+            sol = lx.linear_solve(operator, vector, state=state, solver=solver)
+            return sol.value
 
-                sol = lx.linear_solve(operator, vector, state=state, solver=solver)
-                return sol.value
+    else:
 
-        else:
+        def linear_solve1(operator, vector):
+            sol = lx.linear_solve(operator, vector, solver=solver)
+            return sol.value
 
-            def linear_solve1(operator, vector):
-                sol = lx.linear_solve(operator, vector, solver=solver)
-                return sol.value
+    if pseudoinverse:
+        jnp_solve1 = lambda mat, vec: jnp.linalg.lstsq(mat, vec)[0]  # pyright: ignore
+    else:
+        jnp_solve1 = jnp.linalg.solve  # pyright: ignore
 
-        if pseudoinverse:
-            jnp_solve1 = lambda mat, vec: jnp.linalg.lstsq(mat, vec)[0]  # pyright: ignore
-        else:
-            jnp_solve1 = jnp.linalg.solve  # pyright: ignore
+    linear_solve2 = ft.partial(eqx.filter_jvp, linear_solve1)
+    jnp_solve2 = ft.partial(eqx.filter_jvp, jnp_solve1)
 
-        linear_solve2 = ft.partial(eqx.filter_jvp, linear_solve1)
-        jnp_solve2 = ft.partial(eqx.filter_jvp, jnp_solve1)
+    def _make_primal_tangents(mode):
+        lx_args = ([], [], operator, t_operator, tt_operator, tt_t_operator)
+        jnp_args = ([], [], matrix, t_matrix, tt_matrix, tt_t_matrix)
+        for primals, ttangents, op, t_op, tt_op, tt_t_op in (lx_args, jnp_args):
+            if "op" in mode:
+                primals.append(op)
+                ttangents.append(tt_op)
+            if "vec" in mode:
+                primals.append(vec)
+                ttangents.append(tt_vec)
+            if "t_op" in mode:
+                primals.append(t_op)
+                ttangents.append(tt_t_op)
+            if "t_vec" in mode:
+                primals.append(t_vec)
+                ttangents.append(tt_t_vec)
+        lx_out = tuple(lx_args[0]), tuple(lx_args[1])
+        jnp_out = tuple(jnp_args[0]), tuple(jnp_args[1])
+        return lx_out, jnp_out
 
-        def _make_primal_tangents(mode):
-            lx_args = ([], [], operator, t_operator, tt_operator, tt_t_operator)
-            jnp_args = ([], [], matrix, t_matrix, tt_matrix, tt_t_matrix)
-            for primals, ttangents, op, t_op, tt_op, tt_t_op in (lx_args, jnp_args):
-                if "op" in mode:
-                    primals.append(op)
-                    ttangents.append(tt_op)
-                if "vec" in mode:
-                    primals.append(vec)
-                    ttangents.append(tt_vec)
-                if "t_op" in mode:
-                    primals.append(t_op)
-                    ttangents.append(tt_t_op)
-                if "t_vec" in mode:
-                    primals.append(t_vec)
-                    ttangents.append(tt_t_vec)
-            lx_out = tuple(lx_args[0]), tuple(lx_args[1])
-            jnp_out = tuple(jnp_args[0]), tuple(jnp_args[1])
-            return lx_out, jnp_out
-
-        modes = (
-            {"op"},
-            {"vec"},
-            {"t_op"},
-            {"t_vec"},
-            {"op", "vec"},
-            {"op", "t_op"},
-            {"op", "t_vec"},
-            {"vec", "t_op"},
-            {"vec", "t_vec"},
-            {"op", "vec", "t_op"},
-            {"op", "vec", "t_vec"},
-            {"vec", "t_op", "t_vec"},
-            {"op", "vec", "t_op", "t_vec"},
-        )
-        for mode in modes:
-            if mode == {"op"}:
-                linear_solve3 = lambda op: linear_solve2((op, vec), (t_operator, t_vec))
-                jnp_solve3 = lambda mat: jnp_solve2((mat, vec), (t_matrix, t_vec))
-            elif mode == {"vec"}:
-                linear_solve3 = lambda v: linear_solve2(
-                    (operator, v), (t_operator, t_vec)
-                )
-                jnp_solve3 = lambda v: jnp_solve2((matrix, v), (t_matrix, t_vec))
-            elif mode == {"op", "vec"}:
-                linear_solve3 = lambda op, v: linear_solve2(
-                    (op, v), (t_operator, t_vec)
-                )
-                jnp_solve3 = lambda mat, v: jnp_solve2((mat, v), (t_matrix, t_vec))
-            elif mode == {"t_op"}:
-                linear_solve3 = lambda t_op: linear_solve2(
-                    (operator, vec), (t_op, t_vec)
-                )
-                jnp_solve3 = lambda t_mat: jnp_solve2((matrix, vec), (t_mat, t_vec))
-            elif mode == {"t_vec"}:
-                linear_solve3 = lambda t_v: linear_solve2(
-                    (operator, vec), (t_operator, t_v)
-                )
-                jnp_solve3 = lambda t_v: jnp_solve2((matrix, vec), (t_matrix, t_v))
-            elif mode == {"op", "vec"}:
-                linear_solve3 = lambda op, v: linear_solve2(
-                    (op, v), (t_operator, t_vec)
-                )
-                jnp_solve3 = lambda mat, v: jnp_solve2((mat, v), (t_matrix, t_vec))
-            elif mode == {"op", "t_op"}:
-                linear_solve3 = lambda op, t_op: linear_solve2((op, vec), (t_op, t_vec))
-                jnp_solve3 = lambda mat, t_mat: jnp_solve2((mat, vec), (t_mat, t_vec))
-            elif mode == {"op", "t_vec"}:
-                linear_solve3 = lambda op, t_v: linear_solve2(
-                    (op, vec), (t_operator, t_v)
-                )
-                jnp_solve3 = lambda mat, t_v: jnp_solve2((mat, vec), (t_matrix, t_v))
-            elif mode == {"vec", "t_op"}:
-                linear_solve3 = lambda v, t_op: linear_solve2(
-                    (operator, v), (t_op, t_vec)
-                )
-                jnp_solve3 = lambda v, t_mat: jnp_solve2((matrix, v), (t_mat, t_vec))
-            elif mode == {"vec", "t_vec"}:
-                linear_solve3 = lambda v, t_v: linear_solve2(
-                    (operator, v), (t_operator, t_v)
-                )
-                jnp_solve3 = lambda v, t_v: jnp_solve2((matrix, v), (t_matrix, t_v))
-            elif mode == {"op", "vec", "t_op"}:
-                linear_solve3 = lambda op, v, t_op: linear_solve2(
-                    (op, v), (t_op, t_vec)
-                )
-                jnp_solve3 = lambda mat, v, t_mat: jnp_solve2((mat, v), (t_mat, t_vec))
-            elif mode == {"op", "vec", "t_vec"}:
-                linear_solve3 = lambda op, v, t_v: linear_solve2(
-                    (op, v), (t_operator, t_v)
-                )
-                jnp_solve3 = lambda mat, v, t_v: jnp_solve2((mat, v), (t_matrix, t_v))
-            elif mode == {"vec", "t_op", "t_vec"}:
-                linear_solve3 = lambda v, t_op, t_v: linear_solve2(
-                    (operator, v), (t_op, t_v)
-                )
-                jnp_solve3 = lambda v, t_mat, t_v: jnp_solve2((matrix, v), (t_mat, t_v))
-            elif mode == {"op", "vec", "t_op", "t_vec"}:
-                linear_solve3 = lambda op, v, t_op, t_v: linear_solve2(
-                    (op, v), (t_op, t_v)
-                )
-                jnp_solve3 = lambda mat, v, t_mat, t_v: jnp_solve2(
-                    (mat, v), (t_mat, t_v)
-                )
-            else:
-                assert False
-
-            linear_solve3 = ft.partial(eqx.filter_jvp, linear_solve3)
-            linear_solve3 = eqx.filter_jit(linear_solve3)
-            jnp_solve3 = ft.partial(eqx.filter_jvp, jnp_solve3)
-            jnp_solve3 = eqx.filter_jit(jnp_solve3)
-
-            (primal, tangent), (jnp_primal, jnp_tangent) = _make_primal_tangents(mode)
-            (out, t_out), (minus_out, tt_out) = linear_solve3(primal, tangent)
-            (true_out, true_t_out), (minus_true_out, true_tt_out) = jnp_solve3(
-                jnp_primal, jnp_tangent
+    modes = (
+        {"op"},
+        {"vec"},
+        {"t_op"},
+        {"t_vec"},
+        {"op", "vec"},
+        {"op", "t_op"},
+        {"op", "t_vec"},
+        {"vec", "t_op"},
+        {"vec", "t_vec"},
+        {"op", "vec", "t_op"},
+        {"op", "vec", "t_vec"},
+        {"vec", "t_op", "t_vec"},
+        {"op", "vec", "t_op", "t_vec"},
+    )
+    for mode in modes:
+        if mode == {"op"}:
+            linear_solve3 = lambda op: linear_solve2((op, vec), (t_operator, t_vec))
+            jnp_solve3 = lambda mat: jnp_solve2((mat, vec), (t_matrix, t_vec))
+        elif mode == {"vec"}:
+            linear_solve3 = lambda v: linear_solve2((operator, v), (t_operator, t_vec))
+            jnp_solve3 = lambda v: jnp_solve2((matrix, v), (t_matrix, t_vec))
+        elif mode == {"op", "vec"}:
+            linear_solve3 = lambda op, v: linear_solve2((op, v), (t_operator, t_vec))
+            jnp_solve3 = lambda mat, v: jnp_solve2((mat, v), (t_matrix, t_vec))
+        elif mode == {"t_op"}:
+            linear_solve3 = lambda t_op: linear_solve2((operator, vec), (t_op, t_vec))
+            jnp_solve3 = lambda t_mat: jnp_solve2((matrix, vec), (t_mat, t_vec))
+        elif mode == {"t_vec"}:
+            linear_solve3 = lambda t_v: linear_solve2(
+                (operator, vec), (t_operator, t_v)
             )
+            jnp_solve3 = lambda t_v: jnp_solve2((matrix, vec), (t_matrix, t_v))
+        elif mode == {"op", "vec"}:
+            linear_solve3 = lambda op, v: linear_solve2((op, v), (t_operator, t_vec))
+            jnp_solve3 = lambda mat, v: jnp_solve2((mat, v), (t_matrix, t_vec))
+        elif mode == {"op", "t_op"}:
+            linear_solve3 = lambda op, t_op: linear_solve2((op, vec), (t_op, t_vec))
+            jnp_solve3 = lambda mat, t_mat: jnp_solve2((mat, vec), (t_mat, t_vec))
+        elif mode == {"op", "t_vec"}:
+            linear_solve3 = lambda op, t_v: linear_solve2((op, vec), (t_operator, t_v))
+            jnp_solve3 = lambda mat, t_v: jnp_solve2((mat, vec), (t_matrix, t_v))
+        elif mode == {"vec", "t_op"}:
+            linear_solve3 = lambda v, t_op: linear_solve2((operator, v), (t_op, t_vec))
+            jnp_solve3 = lambda v, t_mat: jnp_solve2((matrix, v), (t_mat, t_vec))
+        elif mode == {"vec", "t_vec"}:
+            linear_solve3 = lambda v, t_v: linear_solve2(
+                (operator, v), (t_operator, t_v)
+            )
+            jnp_solve3 = lambda v, t_v: jnp_solve2((matrix, v), (t_matrix, t_v))
+        elif mode == {"op", "vec", "t_op"}:
+            linear_solve3 = lambda op, v, t_op: linear_solve2((op, v), (t_op, t_vec))
+            jnp_solve3 = lambda mat, v, t_mat: jnp_solve2((mat, v), (t_mat, t_vec))
+        elif mode == {"op", "vec", "t_vec"}:
+            linear_solve3 = lambda op, v, t_v: linear_solve2((op, v), (t_operator, t_v))
+            jnp_solve3 = lambda mat, v, t_v: jnp_solve2((mat, v), (t_matrix, t_v))
+        elif mode == {"vec", "t_op", "t_vec"}:
+            linear_solve3 = lambda v, t_op, t_v: linear_solve2(
+                (operator, v), (t_op, t_v)
+            )
+            jnp_solve3 = lambda v, t_mat, t_v: jnp_solve2((matrix, v), (t_mat, t_v))
+        elif mode == {"op", "vec", "t_op", "t_vec"}:
+            linear_solve3 = lambda op, v, t_op, t_v: linear_solve2((op, v), (t_op, t_v))
+            jnp_solve3 = lambda mat, v, t_mat, t_v: jnp_solve2((mat, v), (t_mat, t_v))
+        else:
+            assert False
 
-            assert tree_allclose(out, true_out, atol=1e-4)
-            assert tree_allclose(t_out, true_t_out, atol=1e-4)
-            assert tree_allclose(tt_out, true_tt_out, atol=1e-4)
-            assert tree_allclose(minus_out, minus_true_out, atol=1e-4)
+        linear_solve3 = ft.partial(eqx.filter_jvp, linear_solve3)
+        linear_solve3 = eqx.filter_jit(linear_solve3)
+        jnp_solve3 = ft.partial(eqx.filter_jvp, jnp_solve3)
+        jnp_solve3 = eqx.filter_jit(jnp_solve3)
+
+        (primal, tangent), (jnp_primal, jnp_tangent) = _make_primal_tangents(mode)
+        (out, t_out), (minus_out, tt_out) = linear_solve3(primal, tangent)
+        (true_out, true_t_out), (minus_true_out, true_tt_out) = jnp_solve3(
+            jnp_primal, jnp_tangent
+        )
+
+        assert tree_allclose(out, true_out, atol=1e-4)
+        assert tree_allclose(t_out, true_t_out, atol=1e-4)
+        assert tree_allclose(tt_out, true_tt_out, atol=1e-4)
+        assert tree_allclose(minus_out, minus_true_out, atol=1e-4)

--- a/tests/test_jvp.py
+++ b/tests/test_jvp.py
@@ -35,86 +35,75 @@ from .helpers import (
 @pytest.mark.parametrize("make_operator", (make_matrix_operator, make_jac_operator))
 @pytest.mark.parametrize("solver, tags, pseudoinverse", solvers_tags_pseudoinverse)
 @pytest.mark.parametrize("use_state", (True, False))
-@pytest.mark.parametrize(
-    "make_matrix",
-    (
-        construct_matrix,
-        construct_singular_matrix,
-    ),
-)
 @pytest.mark.parametrize("dtype", (jnp.float64, jnp.complex128))
-def test_jvp(
-    getkey, solver, tags, pseudoinverse, make_operator, use_state, make_matrix, dtype
-):
+def test_jvp(getkey, solver, tags, pseudoinverse, make_operator, use_state, dtype):
     t_tags = (None,) * len(tags) if isinstance(tags, tuple) else None
 
-    if (make_matrix is construct_matrix) or pseudoinverse:
-        matrix, t_matrix = make_matrix(getkey, solver, tags, num=2, dtype=dtype)
+    make_matrix = construct_singular_matrix if pseudoinverse else construct_matrix
+    matrix, t_matrix = make_matrix(getkey, solver, tags, num=2, dtype=dtype)
 
-        out_size, _ = matrix.shape
-        vec = jr.normal(getkey(), (out_size,), dtype=dtype)
-        t_vec = jr.normal(getkey(), (out_size,), dtype=dtype)
+    out_size, _ = matrix.shape
+    vec = jr.normal(getkey(), (out_size,), dtype=dtype)
+    t_vec = jr.normal(getkey(), (out_size,), dtype=dtype)
 
-        if has_tag(tags, lx.unit_diagonal_tag):
-            # For all the other tags, A + εB with A, B \in {matrices satisfying the tag}
-            # still satisfies the tag itself.
-            # This is the exception.
-            t_matrix.at[jnp.arange(3), jnp.arange(3)].set(0)
+    if has_tag(tags, lx.unit_diagonal_tag):
+        # For all the other tags, A + εB with A, B \in {matrices satisfying the tag}
+        # still satisfies the tag itself.
+        # This is the exception.
+        t_matrix.at[jnp.arange(3), jnp.arange(3)].set(0)
 
-        make_op = ft.partial(make_operator, getkey)
-        operator, t_operator = eqx.filter_jvp(
-            make_op, (matrix, tags), (t_matrix, t_tags)
-        )
+    make_op = ft.partial(make_operator, getkey)
+    operator, t_operator = eqx.filter_jvp(make_op, (matrix, tags), (t_matrix, t_tags))
 
-        if use_state:
-            state = solver.init(operator, options={})
-            linear_solve = ft.partial(lx.linear_solve, state=state)
-        else:
-            linear_solve = lx.linear_solve
+    if use_state:
+        state = solver.init(operator, options={})
+        linear_solve = ft.partial(lx.linear_solve, state=state)
+    else:
+        linear_solve = lx.linear_solve
 
-        solve_vec_only = lambda v: linear_solve(operator, v, solver).value
-        solve_op_only = lambda op: linear_solve(op, vec, solver).value
-        solve_op_vec = lambda op, v: linear_solve(op, v, solver).value
+    solve_vec_only = lambda v: linear_solve(operator, v, solver).value
+    solve_op_only = lambda op: linear_solve(op, vec, solver).value
+    solve_op_vec = lambda op, v: linear_solve(op, v, solver).value
 
-        vec_out, t_vec_out = eqx.filter_jvp(solve_vec_only, (vec,), (t_vec,))
-        op_out, t_op_out = eqx.filter_jvp(solve_op_only, (operator,), (t_operator,))
-        op_vec_out, t_op_vec_out = eqx.filter_jvp(
-            solve_op_vec,
-            (operator, vec),
-            (t_operator, t_vec),
-        )
-        (expected_op_out, *_), (t_expected_op_out, *_) = eqx.filter_jvp(
+    vec_out, t_vec_out = eqx.filter_jvp(solve_vec_only, (vec,), (t_vec,))
+    op_out, t_op_out = eqx.filter_jvp(solve_op_only, (operator,), (t_operator,))
+    op_vec_out, t_op_vec_out = eqx.filter_jvp(
+        solve_op_vec,
+        (operator, vec),
+        (t_operator, t_vec),
+    )
+    (expected_op_out, *_), (t_expected_op_out, *_) = eqx.filter_jvp(
+        lambda op: jnp.linalg.lstsq(op, vec),  # pyright: ignore
+        (matrix,),
+        (t_matrix,),
+    )
+    (expected_op_vec_out, *_), (t_expected_op_vec_out, *_) = eqx.filter_jvp(
+        jnp.linalg.lstsq,
+        (matrix, vec),
+        (t_matrix, t_vec),  # pyright: ignore
+    )
+
+    # Work around JAX issue #14868.
+    if jnp.any(jnp.isnan(t_expected_op_out)):
+        _, (t_expected_op_out, *_) = finite_difference_jvp(
             lambda op: jnp.linalg.lstsq(op, vec),  # pyright: ignore
             (matrix,),
             (t_matrix,),
         )
-        (expected_op_vec_out, *_), (t_expected_op_vec_out, *_) = eqx.filter_jvp(
+    if jnp.any(jnp.isnan(t_expected_op_vec_out)):
+        _, (t_expected_op_vec_out, *_) = finite_difference_jvp(
             jnp.linalg.lstsq,
             (matrix, vec),
             (t_matrix, t_vec),  # pyright: ignore
         )
 
-        # Work around JAX issue #14868.
-        if jnp.any(jnp.isnan(t_expected_op_out)):
-            _, (t_expected_op_out, *_) = finite_difference_jvp(
-                lambda op: jnp.linalg.lstsq(op, vec),  # pyright: ignore
-                (matrix,),
-                (t_matrix,),
-            )
-        if jnp.any(jnp.isnan(t_expected_op_vec_out)):
-            _, (t_expected_op_vec_out, *_) = finite_difference_jvp(
-                jnp.linalg.lstsq,
-                (matrix, vec),
-                (t_matrix, t_vec),  # pyright: ignore
-            )
+    pinv_matrix = jnp.linalg.pinv(matrix)  # pyright: ignore
+    expected_vec_out = pinv_matrix @ vec
+    assert tree_allclose(vec_out, expected_vec_out)
+    assert tree_allclose(op_out, expected_op_out)
+    assert tree_allclose(op_vec_out, expected_op_vec_out)
 
-        pinv_matrix = jnp.linalg.pinv(matrix)  # pyright: ignore
-        expected_vec_out = pinv_matrix @ vec
-        assert tree_allclose(vec_out, expected_vec_out)
-        assert tree_allclose(op_out, expected_op_out)
-        assert tree_allclose(op_vec_out, expected_op_vec_out)
-
-        t_expected_vec_out = pinv_matrix @ t_vec
-        assert tree_allclose(matrix @ t_vec_out, matrix @ t_expected_vec_out, rtol=1e-3)
-        assert tree_allclose(t_op_out, t_expected_op_out, rtol=1e-3)
-        assert tree_allclose(t_op_vec_out, t_expected_op_vec_out, rtol=1e-3)
+    t_expected_vec_out = pinv_matrix @ t_vec
+    assert tree_allclose(matrix @ t_vec_out, matrix @ t_expected_vec_out, rtol=1e-3)
+    assert tree_allclose(t_op_out, t_expected_op_out, rtol=1e-3)
+    assert tree_allclose(t_op_vec_out, t_expected_op_vec_out, rtol=1e-3)

--- a/tests/test_jvp_jvp1.py
+++ b/tests/test_jvp_jvp1.py
@@ -35,11 +35,9 @@ def _clear_cache():
 @pytest.mark.parametrize("solver, tags, pseudoinverse", solvers_tags_pseudoinverse)
 @pytest.mark.parametrize("make_operator", (make_matrix_operator, make_jac_operator))
 @pytest.mark.parametrize("use_state", (True, False))
-@pytest.mark.parametrize("make_matrix", (construct_matrix, construct_singular_matrix))
 @pytest.mark.parametrize("dtype", (jnp.float64,))
-def test_jvp_jvp(
-    getkey, solver, tags, pseudoinverse, make_operator, use_state, make_matrix, dtype
-):
+def test_jvp_jvp(getkey, solver, tags, pseudoinverse, make_operator, use_state, dtype):
+    make_matrix = construct_singular_matrix if pseudoinverse else construct_matrix
     jvp_jvp_impl(
         getkey,
         solver,

--- a/tests/test_jvp_jvp2.py
+++ b/tests/test_jvp_jvp2.py
@@ -35,11 +35,9 @@ def _clear_cache():
 @pytest.mark.parametrize("solver, tags, pseudoinverse", solvers_tags_pseudoinverse)
 @pytest.mark.parametrize("make_operator", (make_matrix_operator, make_jac_operator))
 @pytest.mark.parametrize("use_state", (True, False))
-@pytest.mark.parametrize("make_matrix", (construct_matrix, construct_singular_matrix))
 @pytest.mark.parametrize("dtype", (jnp.complex128,))
-def test_jvp_jvp(
-    getkey, solver, tags, pseudoinverse, make_operator, use_state, make_matrix, dtype
-):
+def test_jvp_jvp(getkey, solver, tags, pseudoinverse, make_operator, use_state, dtype):
+    make_matrix = construct_singular_matrix if pseudoinverse else construct_matrix
     jvp_jvp_impl(
         getkey,
         solver,

--- a/tests/test_singular.py
+++ b/tests/test_singular.py
@@ -33,7 +33,7 @@ from .helpers import (
 )
 
 
-@pytest.mark.parametrize("make_operator,solver,tags", params(only_pseudo=True))
+@pytest.mark.parametrize("make_operator,solver,tags", params(pseudo=True))
 @pytest.mark.parametrize("ops", ops)
 @pytest.mark.parametrize("dtype", (jnp.float64, jnp.complex128))
 def test_small_singular(make_operator, solver, tags, ops, getkey, dtype):
@@ -104,6 +104,8 @@ def test_gmres_stagnation_or_breakdown(getkey, dtype):
     (
         lx.AutoLinearSolver(well_posed=None),
         lx.QR(),
+        lx.QRP(),
+        lx.QRP(rank_defect=0),
         lx.SVD(),
         lx.LSMR(atol=tol, rtol=tol),
         lx.Normal(lx.Cholesky()),
@@ -127,6 +129,8 @@ def test_nonsquare_pytree_operator1(solver):
     (
         lx.AutoLinearSolver(well_posed=None),
         lx.QR(),
+        lx.QRP(),
+        lx.QRP(rank_defect=0),
         lx.SVD(),
         lx.LSMR(atol=tol, rtol=tol),
         lx.Normal(lx.Cholesky()),
@@ -146,16 +150,21 @@ def test_nonsquare_pytree_operator2(solver):
 
 
 @pytest.mark.parametrize(
-    "solver",
+    "solver, full_rank",
     (
-        lx.AutoLinearSolver(well_posed=None),
-        lx.QR(),
-        lx.SVD(),
-        lx.Normal(lx.Cholesky()),
-        lx.Normal(lx.SVD()),
+        (lx.AutoLinearSolver(well_posed=None), True),
+        (lx.QR(), True),
+        (lx.QRP(), True),
+        (lx.QRP(), False),
+        (lx.QRP(rank_defect=0), True),
+        (lx.QRP(rank_defect=1), False),
+        (lx.SVD(), True),
+        (lx.SVD(), False),
+        (lx.Normal(lx.Cholesky()), True),
+        (lx.Normal(lx.SVD()), True),
+        (lx.Normal(lx.SVD()), False),
     ),
 )
-@pytest.mark.parametrize("full_rank", (True, False))
 @pytest.mark.parametrize("jvp", (False, True))
 @pytest.mark.parametrize("wide", (False, True))
 @pytest.mark.parametrize("dtype", (jnp.float64, jnp.complex128))
@@ -168,9 +177,6 @@ def test_nonsquare_mat_vec(solver, full_rank, jvp, wide, dtype, getkey):
         in_size = 3
     matrix = jr.normal(getkey(), (out_size, in_size), dtype=dtype)
     if not full_rank:
-        if solver.assume_full_rank():
-            # There is nothing to test.
-            return
         # nontrivial rank 2 sparsity pattern
         matrix = matrix.at[1:, 1:].set(0)
     vector = jr.normal(getkey(), (out_size,), dtype=dtype)
@@ -197,16 +203,21 @@ def test_nonsquare_mat_vec(solver, full_rank, jvp, wide, dtype, getkey):
 
 
 @pytest.mark.parametrize(
-    "solver",
+    "solver, full_rank",
     (
-        lx.AutoLinearSolver(well_posed=None),
-        lx.QR(),
-        lx.SVD(),
-        lx.Normal(lx.Cholesky()),
-        lx.Normal(lx.SVD()),
+        (lx.AutoLinearSolver(well_posed=None), True),
+        (lx.QR(), True),
+        (lx.QRP(), True),
+        (lx.QRP(), False),
+        (lx.QRP(rank_defect=0), True),
+        (lx.QRP(rank_defect=1), False),
+        (lx.SVD(), True),
+        (lx.SVD(), False),
+        (lx.Normal(lx.Cholesky()), True),
+        (lx.Normal(lx.SVD()), True),
+        (lx.Normal(lx.SVD()), False),
     ),
 )
-@pytest.mark.parametrize("full_rank", (True, False))
 @pytest.mark.parametrize("jvp", (False, True))
 @pytest.mark.parametrize("wide", (False, True))
 @pytest.mark.parametrize("dtype", (jnp.float64, jnp.complex128))
@@ -219,9 +230,6 @@ def test_nonsquare_vec(solver, full_rank, jvp, wide, dtype, getkey):
         in_size = 3
     matrix = jr.normal(getkey(), (out_size, in_size), dtype=dtype)
     if not full_rank:
-        if solver.assume_full_rank():
-            # There is nothing to test.
-            return
         # nontrivial rank 2 sparsity pattern
         matrix = matrix.at[1:, 1:].set(0)
     vector = jr.normal(getkey(), (out_size,), dtype=dtype)
@@ -268,3 +276,24 @@ def test_iterative_singular(getkey, solver, tags, use_state, make_operator, dtyp
 
     with pytest.raises(Exception):
         linear_solve(operator, vec, solver)
+
+
+@pytest.mark.parametrize("make_operator", (make_matrix_operator, make_jac_operator))
+@pytest.mark.parametrize("use_state", (False, True))
+@pytest.mark.parametrize("dtype", (jnp.float64, jnp.complex128))
+@pytest.mark.parametrize("rank_defect", (0, 2))
+def test_qrp_wrong_rank(getkey, use_state, make_operator, dtype, rank_defect):
+    solver = lx.QRP(rank_defect=rank_defect, rcond=float(jnp.finfo(dtype).eps * 6))
+
+    (matrix,) = construct_singular_matrix(getkey, solver, ())
+    operator = make_operator(getkey, matrix, ())
+
+    out_size, _ = matrix.shape
+    vec = jr.normal(getkey(), (out_size,), dtype=dtype)
+
+    if use_state:
+        with pytest.raises(Exception):
+            solver.init(operator, options={})
+    else:
+        with pytest.raises(Exception):
+            lx.linear_solve(operator, vec, solver)

--- a/tests/test_solve.py
+++ b/tests/test_solve.py
@@ -61,7 +61,9 @@ def test_nontrivial_diagonal_operator():
     assert tree_allclose(out, true_out)
 
 
-@pytest.mark.parametrize("solver", (lx.LU(), lx.QR(), lx.SVD()))
+@pytest.mark.parametrize(
+    "solver", (lx.LU(), lx.QR(), lx.SVD(), lx.QRP(), lx.QRP(rank_defect=0))
+)
 def test_mixed_dtypes(solver):
     f32 = lambda x: jnp.array(x, dtype=jnp.float32)
     f64 = lambda x: jnp.array(x, dtype=jnp.float64)
@@ -74,7 +76,9 @@ def test_mixed_dtypes(solver):
     assert tree_allclose(out, true_out)
 
 
-@pytest.mark.parametrize("solver", (lx.LU(), lx.QR(), lx.SVD()))
+@pytest.mark.parametrize(
+    "solver", (lx.LU(), lx.QR(), lx.SVD(), lx.QRP(), lx.QRP(rank_defect=0))
+)
 def test_mixed_dtypes_complex(solver):
     c64 = lambda x: jnp.array(x, dtype=jnp.complex64)
     c128 = lambda x: jnp.array(x, dtype=jnp.complex128)
@@ -87,7 +91,9 @@ def test_mixed_dtypes_complex(solver):
     assert tree_allclose(out, true_out)
 
 
-@pytest.mark.parametrize("solver", (lx.LU(), lx.QR(), lx.SVD()))
+@pytest.mark.parametrize(
+    "solver", (lx.LU(), lx.QR(), lx.SVD(), lx.QRP(), lx.QRP(rank_defect=0))
+)
 def test_mixed_dtypes_complex_real(solver):
     f64 = lambda x: jnp.array(x, dtype=jnp.float64)
     c128 = lambda x: jnp.array(x, dtype=jnp.complex128)

--- a/tests/test_solve.py
+++ b/tests/test_solve.py
@@ -194,6 +194,55 @@ def test_iterative_solver_max_steps_only(solver):
     lx.linear_solve(poisson_operator, rhs, solver)
 
 
+def test_solver_init_not_differentiated(getkey):
+    """stop_gradient should be applied before solver.init, not after.
+
+    Also checks that dynamic arrays in options don't cause issues.
+    """
+
+    class DisallowGradWrapper(lx._solve.AbstractLinearSolver):
+        solver: lx._solve.AbstractLinearSolver
+
+        def init(self, operator, options):
+            @jax.custom_jvp
+            def f(operator, dummy):
+                del dummy
+                return self.solver.init(operator, options)
+
+            @f.defjvp
+            def _(*args):
+                raise NotImplementedError("solver.init should not be differentiated")
+
+            return f(operator, options.get("dummy"))
+
+        def compute(self, state, vector, options):
+            return self.solver.compute(state, vector, options)
+
+        def transpose(self, state, options):
+            return self.solver.transpose(state, options)
+
+        def conj(self, state, options):
+            return self.solver.conj(state, options)
+
+        def assume_full_rank(self):
+            return self.solver.assume_full_rank()
+
+    m = jax.random.normal(getkey(), (3, 3))
+    mt = jax.random.normal(getkey(), (3, 3))
+    v = jax.random.normal(getkey(), (3,))
+    dummy = jnp.array(1.0)
+
+    def f(m):
+        op = lx.MatrixLinearOperator(m)
+        return lx.linear_solve(
+            op, v, solver=DisallowGradWrapper(lx.QR()), options={"dummy": dummy}
+        ).value
+
+    # Differentiating through operator only, but options has a dynamic array.
+    # solver.init should not be differentiated through.
+    jax.jvp(f, (m,), (mt,))
+
+
 def test_nonfinite_input():
     operator = lx.DiagonalLinearOperator((1.0, 1.0))
     vector = (1.0, jnp.inf)

--- a/tests/test_transpose.py
+++ b/tests/test_transpose.py
@@ -38,7 +38,7 @@ class TestTranspose:
 
         return assert_transpose
 
-    @pytest.mark.parametrize("make_operator,solver,tags", params(only_pseudo=False))
+    @pytest.mark.parametrize("make_operator,solver,tags", params(pseudo=False))
     @pytest.mark.parametrize("dtype", (jnp.float64, jnp.complex128))
     def test_transpose(
         _, make_operator, solver, tags, assert_transpose_fixture, dtype, getkey

--- a/tests/test_vmap.py
+++ b/tests/test_vmap.py
@@ -32,61 +32,50 @@ from .helpers import (
 @pytest.mark.parametrize("make_operator", (make_matrix_operator, make_jac_operator))
 @pytest.mark.parametrize("solver, tags, pseudoinverse", solvers_tags_pseudoinverse)
 @pytest.mark.parametrize("use_state", (True, False))
-@pytest.mark.parametrize(
-    "make_matrix",
-    (
-        construct_matrix,
-        construct_singular_matrix,
-    ),
-)
 @pytest.mark.parametrize("dtype", (jnp.float64, jnp.complex128))
-def test_vmap(
-    getkey, make_operator, solver, tags, pseudoinverse, use_state, make_matrix, dtype
-):
-    if (make_matrix is construct_matrix) or pseudoinverse:
+def test_vmap(getkey, make_operator, solver, tags, pseudoinverse, use_state, dtype):
+    make_matrix = construct_singular_matrix if pseudoinverse else construct_matrix
 
-        def wrap_solve(matrix, vector):
-            operator = make_operator(getkey, matrix, tags)
-            if use_state:
-                state = solver.init(operator, options={})
-                return lx.linear_solve(operator, vector, solver, state=state).value
-            else:
-                return lx.linear_solve(operator, vector, solver).value
+    def wrap_solve(matrix, vector):
+        operator = make_operator(getkey, matrix, tags)
+        if use_state:
+            state = solver.init(operator, options={})
+            return lx.linear_solve(operator, vector, solver, state=state).value
+        else:
+            return lx.linear_solve(operator, vector, solver).value
 
-        for op_axis, vec_axis in (
-            (None, 0),
-            (eqx.if_array(0), None),
-            (eqx.if_array(0), 0),
-        ):
-            if op_axis is None:
-                axis_size = None
-                out_axes = None
-            else:
-                axis_size = 10
-                out_axes = eqx.if_array(0)
+    for op_axis, vec_axis in (
+        (None, 0),
+        (eqx.if_array(0), None),
+        (eqx.if_array(0), 0),
+    ):
+        if op_axis is None:
+            axis_size = None
+            out_axes = None
+        else:
+            axis_size = 10
+            out_axes = eqx.if_array(0)
 
-            (matrix,) = eqx.filter_vmap(
-                lambda getkey, solver, tags: make_matrix(
-                    getkey, solver, tags, dtype=dtype
-                ),
-                axis_size=axis_size,
-                out_axes=out_axes,
-            )(getkey, solver, tags)
-            out_dim = matrix.shape[-2]
+        (matrix,) = eqx.filter_vmap(
+            lambda getkey, solver, tags: make_matrix(getkey, solver, tags, dtype=dtype),
+            axis_size=axis_size,
+            out_axes=out_axes,
+        )(getkey, solver, tags)
+        out_dim = matrix.shape[-2]
 
-            if vec_axis is None:
-                vec = jr.normal(getkey(), (out_dim,), dtype=dtype)
-            else:
-                vec = jr.normal(getkey(), (10, out_dim), dtype=dtype)
+        if vec_axis is None:
+            vec = jr.normal(getkey(), (out_dim,), dtype=dtype)
+        else:
+            vec = jr.normal(getkey(), (10, out_dim), dtype=dtype)
 
-            jax_result, _, _, _ = eqx.filter_vmap(
-                jnp.linalg.lstsq,
-                in_axes=(op_axis, vec_axis),  # pyright: ignore
-            )(matrix, vec)
-            lx_result = eqx.filter_vmap(wrap_solve, in_axes=(op_axis, vec_axis))(
-                matrix, vec
-            )
-            assert tree_allclose(lx_result, jax_result)
+        jax_result, _, _, _ = eqx.filter_vmap(
+            jnp.linalg.lstsq,
+            in_axes=(op_axis, vec_axis),  # pyright: ignore
+        )(matrix, vec)
+        lx_result = eqx.filter_vmap(wrap_solve, in_axes=(op_axis, vec_axis))(
+            matrix, vec
+        )
+        assert tree_allclose(lx_result, jax_result)
 
 
 # https://github.com/patrick-kidger/lineax/issues/101

--- a/tests/test_vmap_jvp.py
+++ b/tests/test_vmap_jvp.py
@@ -54,10 +54,9 @@ def test_vmap_jvp(
         if use_state:
 
             def linear_solve1(operator, vector):
-                state = solver.init(operator, options={})
-                state_dynamic, state_static = eqx.partition(state, eqx.is_inexact_array)
-                state_dynamic = lax.stop_gradient(state_dynamic)
-                state = eqx.combine(state_dynamic, state_static)
+                op_dynamic, op_static = eqx.partition(operator, eqx.is_inexact_array)
+                stopped_operator = eqx.combine(lax.stop_gradient(op_dynamic), op_static)
+                state = solver.init(stopped_operator, options={})
 
                 return lx.linear_solve(operator, vector, state=state, solver=solver)
 

--- a/tests/test_vmap_jvp.py
+++ b/tests/test_vmap_jvp.py
@@ -34,100 +34,90 @@ from .helpers import (
 @pytest.mark.parametrize("solver, tags, pseudoinverse", solvers_tags_pseudoinverse)
 @pytest.mark.parametrize("make_operator", (make_matrix_operator, make_jac_operator))
 @pytest.mark.parametrize("use_state", (True, False))
-@pytest.mark.parametrize(
-    "make_matrix",
-    (
-        construct_matrix,
-        construct_singular_matrix,
-    ),
-)
 @pytest.mark.parametrize("dtype", (jnp.float64, jnp.complex128))
-def test_vmap_jvp(
-    getkey, solver, tags, make_operator, pseudoinverse, use_state, make_matrix, dtype
-):
-    if (make_matrix is construct_matrix) or pseudoinverse:
-        t_tags = (None,) * len(tags) if isinstance(tags, tuple) else None
-        if pseudoinverse:
-            jnp_solve1 = lambda mat, vec: jnp.linalg.lstsq(mat, vec)[0]  # pyright: ignore
+def test_vmap_jvp(getkey, solver, tags, make_operator, pseudoinverse, use_state, dtype):
+    make_matrix = construct_singular_matrix if pseudoinverse else construct_matrix
+    t_tags = (None,) * len(tags) if isinstance(tags, tuple) else None
+    if pseudoinverse:
+        jnp_solve1 = lambda mat, vec: jnp.linalg.lstsq(mat, vec)[0]  # pyright: ignore
+    else:
+        jnp_solve1 = jnp.linalg.solve  # pyright: ignore
+    if use_state:
+
+        def linear_solve1(operator, vector):
+            op_dynamic, op_static = eqx.partition(operator, eqx.is_inexact_array)
+            stopped_operator = eqx.combine(lax.stop_gradient(op_dynamic), op_static)
+            state = solver.init(stopped_operator, options={})
+            return lx.linear_solve(operator, vector, state=state, solver=solver)
+
+    else:
+        linear_solve1 = ft.partial(lx.linear_solve, solver=solver)
+
+    for mode in ("vec", "op", "op_vec"):
+        if "op" in mode:
+            axis_size = 10
+            out_axes = eqx.if_array(0)
         else:
-            jnp_solve1 = jnp.linalg.solve  # pyright: ignore
-        if use_state:
+            axis_size = None
+            out_axes = None
 
-            def linear_solve1(operator, vector):
-                op_dynamic, op_static = eqx.partition(operator, eqx.is_inexact_array)
-                stopped_operator = eqx.combine(lax.stop_gradient(op_dynamic), op_static)
-                state = solver.init(stopped_operator, options={})
+        def _make():
+            matrix, t_matrix = make_matrix(getkey, solver, tags, num=2, dtype=dtype)
+            make_op = ft.partial(make_operator, getkey)
+            operator, t_operator = eqx.filter_jvp(
+                make_op, (matrix, tags), (t_matrix, t_tags)
+            )
+            return matrix, t_matrix, operator, t_operator
 
-                return lx.linear_solve(operator, vector, state=state, solver=solver)
+        matrix, t_matrix, operator, t_operator = eqx.filter_vmap(
+            _make, axis_size=axis_size, out_axes=out_axes
+        )()
 
+        if "op" in mode:
+            _, out_size, _ = matrix.shape
         else:
-            linear_solve1 = ft.partial(lx.linear_solve, solver=solver)
+            out_size, _ = matrix.shape
 
-        for mode in ("vec", "op", "op_vec"):
-            if "op" in mode:
-                axis_size = 10
-                out_axes = eqx.if_array(0)
+        if "vec" in mode:
+            vec = jr.normal(getkey(), (10, out_size), dtype=dtype)
+            t_vec = jr.normal(getkey(), (10, out_size), dtype=dtype)
+        else:
+            vec = jr.normal(getkey(), (out_size,), dtype=dtype)
+            t_vec = jr.normal(getkey(), (out_size,), dtype=dtype)
+
+        if mode == "op":
+            linear_solve2 = lambda op: linear_solve1(op, vector=vec)
+            jnp_solve2 = lambda mat: jnp_solve1(mat, vec)
+        elif mode == "vec":
+            linear_solve2 = lambda vector: linear_solve1(operator, vector)
+            jnp_solve2 = lambda vector: jnp_solve1(matrix, vector)
+        elif mode == "op_vec":
+            linear_solve2 = linear_solve1
+            jnp_solve2 = jnp_solve1
+        else:
+            assert False
+        for jvp_first in (True, False):
+            if jvp_first:
+                linear_solve3 = ft.partial(eqx.filter_jvp, linear_solve2)
             else:
-                axis_size = None
-                out_axes = None
-
-            def _make():
-                matrix, t_matrix = make_matrix(getkey, solver, tags, num=2, dtype=dtype)
-                make_op = ft.partial(make_operator, getkey)
-                operator, t_operator = eqx.filter_jvp(
-                    make_op, (matrix, tags), (t_matrix, t_tags)
-                )
-                return matrix, t_matrix, operator, t_operator
-
-            matrix, t_matrix, operator, t_operator = eqx.filter_vmap(
-                _make, axis_size=axis_size, out_axes=out_axes
-            )()
-
-            if "op" in mode:
-                _, out_size, _ = matrix.shape
-            else:
-                out_size, _ = matrix.shape
-
-            if "vec" in mode:
-                vec = jr.normal(getkey(), (10, out_size), dtype=dtype)
-                t_vec = jr.normal(getkey(), (10, out_size), dtype=dtype)
-            else:
-                vec = jr.normal(getkey(), (out_size,), dtype=dtype)
-                t_vec = jr.normal(getkey(), (out_size,), dtype=dtype)
-
+                linear_solve3 = linear_solve2
+            linear_solve3 = eqx.filter_vmap(linear_solve3)
+            if not jvp_first:
+                linear_solve3 = ft.partial(eqx.filter_jvp, linear_solve3)
+            linear_solve3 = eqx.filter_jit(linear_solve3)
+            jnp_solve3 = ft.partial(eqx.filter_jvp, jnp_solve2)
+            jnp_solve3 = eqx.filter_vmap(jnp_solve3)
+            jnp_solve3 = eqx.filter_jit(jnp_solve3)
             if mode == "op":
-                linear_solve2 = lambda op: linear_solve1(op, vector=vec)
-                jnp_solve2 = lambda mat: jnp_solve1(mat, vec)
+                out, t_out = linear_solve3((operator,), (t_operator,))
+                true_out, true_t_out = jnp_solve3((matrix,), (t_matrix,))
             elif mode == "vec":
-                linear_solve2 = lambda vector: linear_solve1(operator, vector)
-                jnp_solve2 = lambda vector: jnp_solve1(matrix, vector)
+                out, t_out = linear_solve3((vec,), (t_vec,))
+                true_out, true_t_out = jnp_solve3((vec,), (t_vec,))
             elif mode == "op_vec":
-                linear_solve2 = linear_solve1
-                jnp_solve2 = jnp_solve1
+                out, t_out = linear_solve3((operator, vec), (t_operator, t_vec))
+                true_out, true_t_out = jnp_solve3((matrix, vec), (t_matrix, t_vec))
             else:
                 assert False
-            for jvp_first in (True, False):
-                if jvp_first:
-                    linear_solve3 = ft.partial(eqx.filter_jvp, linear_solve2)
-                else:
-                    linear_solve3 = linear_solve2
-                linear_solve3 = eqx.filter_vmap(linear_solve3)
-                if not jvp_first:
-                    linear_solve3 = ft.partial(eqx.filter_jvp, linear_solve3)
-                linear_solve3 = eqx.filter_jit(linear_solve3)
-                jnp_solve3 = ft.partial(eqx.filter_jvp, jnp_solve2)
-                jnp_solve3 = eqx.filter_vmap(jnp_solve3)
-                jnp_solve3 = eqx.filter_jit(jnp_solve3)
-                if mode == "op":
-                    out, t_out = linear_solve3((operator,), (t_operator,))
-                    true_out, true_t_out = jnp_solve3((matrix,), (t_matrix,))
-                elif mode == "vec":
-                    out, t_out = linear_solve3((vec,), (t_vec,))
-                    true_out, true_t_out = jnp_solve3((vec,), (t_vec,))
-                elif mode == "op_vec":
-                    out, t_out = linear_solve3((operator, vec), (t_operator, t_vec))
-                    true_out, true_t_out = jnp_solve3((matrix, vec), (t_matrix, t_vec))
-                else:
-                    assert False
-                assert tree_allclose(out.value, true_out, atol=1e-4)
-                assert tree_allclose(t_out.value, true_t_out, atol=1e-4)
+            assert tree_allclose(out.value, true_out, atol=1e-4)
+            assert tree_allclose(t_out.value, true_t_out, atol=1e-4)

--- a/tests/test_vmap_vmap.py
+++ b/tests/test_vmap_vmap.py
@@ -33,114 +33,107 @@ from .helpers import (
 @pytest.mark.parametrize("make_operator", (make_matrix_operator, make_jac_operator))
 @pytest.mark.parametrize("solver, tags, pseudoinverse", solvers_tags_pseudoinverse)
 @pytest.mark.parametrize("use_state", (True, False))
-@pytest.mark.parametrize(
-    "make_matrix",
-    (
-        construct_matrix,
-        construct_singular_matrix,
-    ),
-)
 @pytest.mark.parametrize("dtype", (jnp.float64, jnp.complex128))
 def test_vmap_vmap(
-    getkey, make_operator, solver, tags, pseudoinverse, use_state, make_matrix, dtype
+    getkey, make_operator, solver, tags, pseudoinverse, use_state, dtype
 ):
-    if (make_matrix is construct_matrix) or pseudoinverse:
-        # combinations with nontrivial application across both vmaps
-        axes = [
-            (eqx.if_array(0), eqx.if_array(0), None, None),
-            (None, None, 0, 0),
-            (eqx.if_array(0), eqx.if_array(0), None, 0),
-            (eqx.if_array(0), eqx.if_array(0), 0, 0),
-            (None, eqx.if_array(0), 0, 0),
-        ]
+    make_matrix = construct_singular_matrix if pseudoinverse else construct_matrix
+    # combinations with nontrivial application across both vmaps
+    axes = [
+        (eqx.if_array(0), eqx.if_array(0), None, None),
+        (None, None, 0, 0),
+        (eqx.if_array(0), eqx.if_array(0), None, 0),
+        (eqx.if_array(0), eqx.if_array(0), 0, 0),
+        (None, eqx.if_array(0), 0, 0),
+    ]
 
-        for vmap2_op, vmap1_op, vmap2_vec, vmap1_vec in axes:
-            if vmap1_op is not None:
-                axis_size1 = 10
-                out_axis1 = eqx.if_array(0)
-            else:
-                axis_size1 = None
-                out_axis1 = None
+    for vmap2_op, vmap1_op, vmap2_vec, vmap1_vec in axes:
+        if vmap1_op is not None:
+            axis_size1 = 10
+            out_axis1 = eqx.if_array(0)
+        else:
+            axis_size1 = None
+            out_axis1 = None
 
+        if vmap2_op is not None:
+            axis_size2 = 10
+            out_axis2 = eqx.if_array(0)
+        else:
+            axis_size2 = None
+            out_axis2 = None
+
+        (matrix,) = eqx.filter_vmap(
+            eqx.filter_vmap(
+                lambda getkey, solver, tags: make_matrix(
+                    getkey, solver, tags, dtype=dtype
+                ),
+                axis_size=axis_size1,
+                out_axes=out_axis1,
+            ),
+            axis_size=axis_size2,
+            out_axes=out_axis2,
+        )(getkey, solver, tags)
+
+        if vmap1_op is not None:
             if vmap2_op is not None:
-                axis_size2 = 10
-                out_axis2 = eqx.if_array(0)
+                _, _, out_size, _ = matrix.shape
             else:
-                axis_size2 = None
-                out_axis2 = None
+                _, out_size, _ = matrix.shape
+        else:
+            out_size, _ = matrix.shape
 
-            (matrix,) = eqx.filter_vmap(
-                eqx.filter_vmap(
-                    lambda getkey, solver, tags: make_matrix(
-                        getkey, solver, tags, dtype=dtype
-                    ),
-                    axis_size=axis_size1,
-                    out_axes=out_axis1,
-                ),
-                axis_size=axis_size2,
-                out_axes=out_axis2,
-            )(getkey, solver, tags)
+        if vmap1_vec is None:
+            vec = jr.normal(getkey(), (out_size,), dtype=dtype)
+        elif (vmap1_vec is not None) and (vmap2_vec is None):
+            vec = jr.normal(getkey(), (10, out_size), dtype=dtype)
+        else:
+            vec = jr.normal(getkey(), (10, 10, out_size), dtype=dtype)
 
-            if vmap1_op is not None:
-                if vmap2_op is not None:
-                    _, _, out_size, _ = matrix.shape
-                else:
-                    _, out_size, _ = matrix.shape
-            else:
-                out_size, _ = matrix.shape
+        make_op = ft.partial(make_operator, getkey)
+        operator = eqx.filter_vmap(
+            eqx.filter_vmap(
+                make_op,
+                in_axes=vmap1_op,
+                out_axes=out_axis1,
+            ),
+            in_axes=vmap2_op,
+            out_axes=out_axis2,
+        )(matrix, tags)
 
-            if vmap1_vec is None:
-                vec = jr.normal(getkey(), (out_size,), dtype=dtype)
-            elif (vmap1_vec is not None) and (vmap2_vec is None):
-                vec = jr.normal(getkey(), (10, out_size), dtype=dtype)
-            else:
-                vec = jr.normal(getkey(), (10, 10, out_size), dtype=dtype)
+        if use_state:
 
-            make_op = ft.partial(make_operator, getkey)
-            operator = eqx.filter_vmap(
-                eqx.filter_vmap(
-                    make_op,
-                    in_axes=vmap1_op,
-                    out_axes=out_axis1,
-                ),
-                in_axes=vmap2_op,
-                out_axes=out_axis2,
-            )(matrix, tags)
+            def linear_solve(operator, vector):
+                state = solver.init(operator, options={})
+                return lx.linear_solve(operator, vector, state=state, solver=solver)
 
-            if use_state:
+        else:
 
-                def linear_solve(operator, vector):
-                    state = solver.init(operator, options={})
-                    return lx.linear_solve(operator, vector, state=state, solver=solver)
+            def linear_solve(operator, vector):
+                return lx.linear_solve(operator, vector, solver)
 
-            else:
+        as_matrix_vmapped = eqx.filter_vmap(
+            eqx.filter_vmap(
+                lambda x: x.as_matrix(),
+                in_axes=vmap1_op,
+                out_axes=None if vmap1_op is None else 0,
+            ),
+            in_axes=vmap2_op,
+            out_axes=None if vmap2_op is None else 0,
+        )(operator)
 
-                def linear_solve(operator, vector):
-                    return lx.linear_solve(operator, vector, solver)
+        vmap1_axes = (vmap1_op, vmap1_vec)
+        vmap2_axes = (vmap2_op, vmap2_vec)
 
-            as_matrix_vmapped = eqx.filter_vmap(
-                eqx.filter_vmap(
-                    lambda x: x.as_matrix(),
-                    in_axes=vmap1_op,
-                    out_axes=None if vmap1_op is None else 0,
-                ),
-                in_axes=vmap2_op,
-                out_axes=None if vmap2_op is None else 0,
-            )(operator)
+        result = eqx.filter_vmap(
+            eqx.filter_vmap(linear_solve, in_axes=vmap1_axes), in_axes=vmap2_axes
+        )(operator, vec).value
 
-            vmap1_axes = (vmap1_op, vmap1_vec)
-            vmap2_axes = (vmap2_op, vmap2_vec)
+        solve_with = lambda x: eqx.filter_vmap(
+            eqx.filter_vmap(x, in_axes=vmap1_axes), in_axes=vmap2_axes
+        )(as_matrix_vmapped, vec)
 
-            result = eqx.filter_vmap(
-                eqx.filter_vmap(linear_solve, in_axes=vmap1_axes), in_axes=vmap2_axes
-            )(operator, vec).value
-
-            solve_with = lambda x: eqx.filter_vmap(
-                eqx.filter_vmap(x, in_axes=vmap1_axes), in_axes=vmap2_axes
-            )(as_matrix_vmapped, vec)
-
-            if make_matrix is construct_singular_matrix:
-                true_result, _, _, _ = solve_with(jnp.linalg.lstsq)  # pyright: ignore
-            else:
-                true_result = solve_with(jnp.linalg.solve)  # pyright: ignore
-            assert tree_allclose(result, true_result, rtol=1e-3)
+        if make_matrix is construct_singular_matrix:
+            true_result, _, _, _ = solve_with(jnp.linalg.lstsq)  # pyright: ignore
+        else:
+            true_result = solve_with(jnp.linalg.solve)  # pyright: ignore
+        assert tree_allclose(result, true_result, rtol=1e-3)

--- a/tests/test_well_posed.py
+++ b/tests/test_well_posed.py
@@ -28,7 +28,7 @@ from .helpers import (
 )
 
 
-@pytest.mark.parametrize("make_operator,solver,tags", params(only_pseudo=False))
+@pytest.mark.parametrize("make_operator,solver,tags", params(pseudo=False))
 @pytest.mark.parametrize("ops", ops)
 @pytest.mark.parametrize("dtype", (jnp.float64, jnp.complex128))
 def test_small_wellposed(make_operator, solver, tags, ops, getkey, dtype):


### PR DESCRIPTION
Let me know your opinions about the design. Most opinionated is the static vs dynamic rank modes, similar to @jpbrodrick89's suggestion https://github.com/patrick-kidger/lineax/issues/201#issuecomment-3994709790. In my design, the user asserts static rank equality, rather than inequality, which I think might be useful in the contexts in which it arises (ie, we are optimizing in the locus of rank r matrices, if we get close to the locus of rank r-1, we might not want the structure of the calculation to suddenly change).

Testing this correctly required some test restructuring (as well as bug fixes). 

There is a jax bug in the jvp rule for pivoted qr in the presence of vmapping, so there are test failures which are resolved by jax-ml/jax#35586. Actually the fact that the tests fail due to a bug in jax qr jvp is a bit mysterious to me because my understanding is that lineax solver jvp should never call the jax qr jvp. I haven't yet investigated further, but I welcome insight into this.

Resolves #141 and #201.