### PR TITLE
jvp optimisations for pseudoinverse solvers

### DIFF
--- a/lineax/_solve.py
+++ b/lineax/_solve.py
@@ -211,16 +211,22 @@ def _linear_solve_jvp(primals, tangents):
         if not assume_independent_rows:
             lst_sqr_diff = (vector**ω - operator.mv(solution) ** ω).ω
             tmp = t_operator_conj_transpose.mv(lst_sqr_diff)  # pyright: ignore
-            tmp, _, _ = eqxi.filter_primitive_bind(
-                linear_solve_p,
-                operator_conj_transpose,  # pyright: ignore
-                state_conj_transpose,  # pyright: ignore
-                tmp,
-                options_conj_transpose,  # pyright: ignore
-                solver,
-                True,
-            )
-            vecs.append(tmp)
+            # Fast path: A†(Aᵀ)†w = (AᵀA)†w directly (e.g. R⁻¹R⁻ᵀw for QR)
+            gram_inv = _gram_inverse_mv(solver, state, tmp)
+            if gram_inv is NotImplemented:
+                tmp, _, _ = eqxi.filter_primitive_bind(
+                    linear_solve_p,
+                    operator_conj_transpose,  # pyright: ignore
+                    state_conj_transpose,  # pyright: ignore
+                    tmp,
+                    options_conj_transpose,  # pyright: ignore
+                    solver,
+                    True,
+                )
+                vecs.append(tmp)
+            else:
+                # Result already lives in input space; bypass outer A† for this term.
+                sols.append(gram_inv)
 
         if not assume_independent_columns:
             tmp1, _, _ = eqxi.filter_primitive_bind(
@@ -234,10 +240,16 @@ def _linear_solve_jvp(primals, tangents):
             )
             tmp2 = t_operator_conj_transpose.mv(tmp1)  # pyright: ignore
             # tmp2 is the y term
-            tmp3 = operator.mv(tmp2)
-            tmp4 = (-(tmp3**ω)).ω
-            # tmp4 is the Ay term
-            vecs.append(tmp4)
+            # Fast path: e.g. A†Ay = QQᵀy for QR, VVᵀy for SVD
+            proj = _row_space_projection(solver, state, tmp2)
+            if proj is NotImplemented:
+                tmp3 = operator.mv(tmp2)
+                tmp4 = (-(tmp3**ω)).ω
+                # tmp4 is the Ay term
+                vecs.append(tmp4)
+            else:
+                # Projection already computed; add -A†Ay directly.
+                sols.append((-(proj**ω)).ω)
             sols.append(tmp2)
     vecs = jtu.tree_map(_sum, *vecs)
     # the A^ term at the very beginning
@@ -466,6 +478,32 @@ class AbstractLinearSolver(eqx.Module, Generic[_SolverState]):
 
         Either `True` or `False`.
         """
+
+
+#
+# These optimisation hooks are singledispatch functions rather than methods on
+# AbstractLinearSolver, following the same pattern as _operator.py.
+#
+
+
+@ft.singledispatch
+def _gram_inverse_mv(solver: "AbstractLinearSolver", state, vector):
+    """Compute $(A^H A)^\\dagger v$ directly, or return `NotImplemented`.
+
+    Used in `_linear_solve_jvp` for the `not assume_independent_rows` branch.
+    Falls back to the generic two-solve chain when `NotImplemented` is returned.
+    """
+    return NotImplemented
+
+
+@ft.singledispatch
+def _row_space_projection(solver: "AbstractLinearSolver", state, vector):
+    """Compute $A^\\dagger A v$ directly, or return `NotImplemented`.
+
+    Used in `_linear_solve_jvp` for the `not assume_independent_columns` branch.
+    Falls back to the generic matvec+solve path when `NotImplemented` is returned.
+    """
+    return NotImplemented
 
 
 _qr_token = eqxi.str2jax("qr_token")

--- a/lineax/_solver/normal.py
+++ b/lineax/_solver/normal.py
@@ -20,7 +20,12 @@ from jaxtyping import Array, PyTree
 
 from .._operator import conj, linearise, materialise, TaggedLinearOperator
 from .._solution import RESULTS
-from .._solve import AbstractLinearOperator, AbstractLinearSolver
+from .._solve import (
+    _gram_inverse_mv,
+    _row_space_projection,
+    AbstractLinearOperator,
+    AbstractLinearSolver,
+)
 from .._tags import positive_semidefinite_tag
 from .cholesky import Cholesky
 
@@ -186,3 +191,43 @@ Normal.__init__.__doc__ = """**Arguments:**
 - `inner_solver`: The solver to wrap. It should support solving positive
   definite systems or positive semidefinite systems
 """
+
+
+@_gram_inverse_mv.register(Normal)
+def _(solver: Normal, state, vector):
+    inner_state, tall, operator_conj_transpose, inner_options = state
+    tall = tall.value
+    del state, operator_conj_transpose
+    if tall:
+        # inner operator IS A^* A
+        result, _, _ = solver.inner_solver.compute(inner_state, vector, inner_options)
+        return result
+    if not tall:
+        if solver.inner_solver.assume_full_rank():
+            # Should be unreachable: assume_independent_rows should be true for wide ops
+            raise NotImplementedError(
+                "Please open a GitHub issue: https://github.com/google/lineax"
+            )
+        # Wide case with non-full-rank inner solver, no suitable solvers currently exist
+        # in lineax but a user may implement one (e.g. Modified Cholesky/LDL)
+        # No fast path exists as cannot compute (A^* A)^† from the stored AA^*
+        return NotImplemented
+
+
+@_row_space_projection.register(Normal)
+def _(solver: Normal, state, vector):
+    inner_state, tall, operator_conj_transpose, inner_options = state
+    del state, operator_conj_transpose, inner_options
+    tall = tall.value
+    if tall:
+        if solver.inner_solver.assume_full_rank():
+            # Should be unreachable: assume_independent_columns should be True for tall
+            raise NotImplementedError(
+                "Please open a GitHub issue: https://github.com/google/lineax"
+            )
+        # Tall case with non-full-rank inner solver, no suitable solvers currently exist
+        # in lineax, but a user may implement one (e.g. Modified Cholesky/LDL)
+        # A^\dagger A = (A^*A)^\dagger A^* A (same row space as inner solver)
+        return _row_space_projection(solver.inner_solver, inner_state, vector)
+    if not tall:
+        return NotImplemented

--- a/lineax/_solver/qr.py
+++ b/lineax/_solver/qr.py
@@ -20,7 +20,7 @@ import jax.scipy as jsp
 from jaxtyping import Array, PyTree
 
 from .._solution import RESULTS
-from .._solve import AbstractLinearSolver
+from .._solve import _gram_inverse_mv, _row_space_projection, AbstractLinearSolver
 from .misc import (
     pack_structures,
     PackedStructures,
@@ -114,3 +114,42 @@ QR.__init__.__doc__ = """**Arguments:**
 
 Nothing.
 """
+
+
+@_gram_inverse_mv.register(QR)
+def _(solver, state: _QRState, vector):
+    (q, r), transpose, packed_structures = state
+    transpose = transpose.value
+    del state
+    if transpose:
+        # Should be unreachable: QR.assume_full_rank() is True, so
+        # assume_independent_rows is always True for wide operators.
+        raise NotImplementedError(
+            "Please open a GitHub issue: https://github.com/google/lineax"
+        )
+    # Tall A = QR: (A^H A)^{-1} v = R^{-1} R^{-H} v.  Q^H Q = I cancels.
+    transposed_packed_structures = transpose_packed_structures(packed_structures)
+    w = ravel_vector(vector, transposed_packed_structures)
+    # trans="C" gives R^{-H} (conjugate-transpose solve)
+    rHw = jsp.linalg.solve_triangular(r, w, trans="C", unit_diagonal=False)
+    result = jsp.linalg.solve_triangular(r, rHw, unit_diagonal=False)
+    return unravel_solution(result, packed_structures)
+
+
+@_row_space_projection.register(QR)
+def _(solver, state: _QRState, vector):
+    (q, r), transpose, packed_structures = state
+    transpose = transpose.value
+    del state
+    if not transpose:
+        # Should be unreachable: QR.assume_full_rank() is True, so
+        # assume_independent_columns is always True for tall operators.
+        raise NotImplementedError(
+            "Please open a GitHub issue: https://github.com/google/lineax"
+        )
+    # Wide A stores QR of A^T = Q₁R₁ => A^†A = Q₁^{-T} R₁^{-T} R₁^T Q₁^T
+    # => A^†A = conj(Q₁) Q₁^T by unitarity — two matvecs, no solve.
+    transposed_packed_structures = transpose_packed_structures(packed_structures)
+    w = ravel_vector(vector, transposed_packed_structures)
+    result = q.conj() @ (q.T @ w)
+    return unravel_solution(result, packed_structures)

--- a/lineax/_solver/svd.py
+++ b/lineax/_solver/svd.py
@@ -22,7 +22,7 @@ from jaxtyping import Array, PyTree
 from .._misc import resolve_rcond
 from .._operator import AbstractLinearOperator
 from .._solution import RESULTS
-from .._solve import AbstractLinearSolver
+from .._solve import _gram_inverse_mv, _row_space_projection, AbstractLinearSolver
 from .misc import (
     pack_structures,
     PackedStructures,
@@ -52,6 +52,14 @@ class SVD(AbstractLinearSolver[_SVDState]):
         packed_structures = pack_structures(operator)
         return svd, packed_structures
 
+    def _singular_mask(self, s, n, m):
+        rcond = resolve_rcond(self.rcond, n, m, s.dtype)
+        rcond = jnp.array(rcond, dtype=s.dtype)
+        if s.size > 0:
+            rcond = rcond * s[0]
+        # Not >=, or this fails with a matrix of all-zeros.
+        return s > rcond
+
     def compute(
         self,
         state: _SVDState,
@@ -63,12 +71,7 @@ class SVD(AbstractLinearSolver[_SVDState]):
         vector = ravel_vector(vector, packed_structures)
         m, _ = u.shape
         _, n = vt.shape
-        rcond = resolve_rcond(self.rcond, n, m, s.dtype)
-        rcond = jnp.array(rcond, dtype=s.dtype)
-        if s.size > 0:
-            rcond = rcond * s[0]
-        # Not >=, or this fails with a matrix of all-zeros.
-        mask = s > rcond
+        mask = self._singular_mask(s, n, m)
         rank = mask.sum()
         safe_s = jnp.where(mask, s, 1)
         s_inv = jnp.where(mask, jnp.array(1.0) / safe_s, 0).astype(u.dtype)
@@ -102,3 +105,32 @@ SVD.__init__.__doc__ = """**Arguments**:
     precision times `max(N, M)`, where `(N, M)` is the shape of the operator. (I.e.
     `N` is the output size and `M` is the input size.)
 """
+
+
+@_gram_inverse_mv.register(SVD)
+def _(solver: SVD, state: _SVDState, vector):
+    (u, s, vt), packed_structures = state
+    m, n = u.shape[0], vt.shape[1]
+    transposed_ps = transpose_packed_structures(packed_structures)
+    w = ravel_vector(vector, transposed_ps)
+    mask = solver._singular_mask(s, n, m)
+    safe_s = jnp.where(mask, s, 1)
+    # (A^H A)^{-1} v = VΣ⁻²V^H v.  U^H U = I cancels entirely.
+    s_inv_sq = jnp.where(mask, 1.0 / safe_s**2, 0).astype(vt.dtype)
+    vt_w = jnp.matmul(vt, w, precision=lax.Precision.HIGHEST)
+    result = jnp.matmul(vt.conj().T, s_inv_sq * vt_w, precision=lax.Precision.HIGHEST)
+    return unravel_solution(result, packed_structures)
+
+
+@_row_space_projection.register(SVD)
+def _(solver: SVD, state: _SVDState, vector):
+    (u, s, vt), packed_structures = state
+    m, n = u.shape[0], vt.shape[1]
+    transposed_ps = transpose_packed_structures(packed_structures)
+    w = ravel_vector(vector, transposed_ps)
+    mask = solver._singular_mask(s, n, m)
+    # A^†A v = VV^H v (restricted to row space).  Σ cancels entirely.
+    vt_w = jnp.matmul(vt, w, precision=lax.Precision.HIGHEST)
+    masked_vt_w = jnp.where(mask, vt_w, 0)
+    result = jnp.matmul(vt.conj().T, masked_vt_w, precision=lax.Precision.HIGHEST)
+    return unravel_solution(result, packed_structures)


### PR DESCRIPTION
**Preamble**
First of all, sincere apologies for adding another PR to the backlog. This is definitely not one that would fit in an extension package due to its invasive change of the `linear_solve` jvp rule, but also is not one I'd mind terribly if you deprioritise reviewing as I don't think its a critical bottleneck in my work. My hope is that submitting it now rather than waiting for the backlog to clear simply means it has more time to swim around in your head for a smoother review when we eventually get there (no pressure! 🙂). Furthermore, this could affect new solvers such as pivoted QR.

**Intention of PR**
I've been working on variable projection as well as thinking about improving Jax's least square JVP rule and comparing to Lineax for inspiration. I noticed we were missing some low-hanging fruit when it comes to leveraging standard optimisations for projection and Gram operators that are used in the JVP rule.

_Dependent columns_

The JVP rule has a term $A^\dagger A y$ which is the projection onto the row space. This has the following optimisations:

* Wide QR: $A^†A = Q^{-\top} R^{-\top} R^\top Q^\top = \mathrm{conj}(Q) Q^\top$ by unitarity—avoiding a matmul and a triangular solve.
* SVD: $A^†A = (U \Sigma V^\top)^†(U \Sigma V^\top) = V \Sigma U^T U \Sigma V^\top = V V^\top$ by unitarity of $U$, saving two O(mn) matmuls.

_Dependent rows_

The JVP rule has a term $A^\dagger A^{H\dagger} \mathrm{d}A^H(b-Ax)$, where the first two matrices can be written as the (pseudo-)inverse of the Gram matrix $A^\dagger A^{H\dagger}=(A^H A)^\dagger$. This has the following optimisations:

* Tall QR: $(A^H A)^\dagger = (R^H Q^H Q R)^{-1} = R^{-1}R^{-H}$ saving two O(mn) matmuls.
* SVD: $(V \Sigma U^H U \Sigma V^H)^\dagger=V \Sigma^{-2} V^H$ saving two O(mn) matmuls.
* Tall Normal: $A^H A$ IS `inner_operator` so we just use a single call to the `inner_solver` and avoid an application of $A$.

**Caveat**

Savings are not always quite as good as they sound as the "vecs" are summed with others that still exist before applying the outer solve, but the saving from the inner matrix is still very real (i.e. savings are about half what they're advertised to be).

**Design**

I have introduced two `singledispatch` functions in `_solve.py`: `_gram_inverse_mv` and `_row_space_projection` which return `NotImplemented` (NOT `raise NotImplementedError`) by default to allow fallback to the current path and otherwise allows leveraging these optimisations in the jvp rule.