### PR TITLE
Use ormqr for more efficient QR solve

### DIFF
--- a/lineax/_solver/qr.py
+++ b/lineax/_solver/qr.py
@@ -15,6 +15,7 @@
 from typing import Any, TypeAlias
 
 import equinox.internal as eqxi
+import jax.lax.linalg as jll
 import jax.numpy as jnp
 import jax.scipy as jsp
 from jaxtyping import Array, PyTree
@@ -58,9 +59,10 @@ class QR(AbstractLinearSolver):
         transpose = n > m
         if transpose:
             matrix = matrix.T
-        qr = jnp.linalg.qr(matrix, mode="reduced")  # pyright: ignore
+        h, taus = jnp.linalg.qr(matrix, mode="raw")  # pyright: ignore
+        a = h.mT
         packed_structures = pack_structures(operator)
-        return qr, eqxi.Static(transpose), packed_structures
+        return (a, taus), eqxi.Static(transpose), packed_structures
 
     def compute(
         self,
@@ -68,28 +70,34 @@ class QR(AbstractLinearSolver):
         vector: PyTree[Array],
         options: dict[str, Any],
     ) -> tuple[PyTree[Array], RESULTS, dict[str, Any]]:
-        (q, r), transpose, packed_structures = state
+        (a, taus), transpose, packed_structures = state
         transpose = transpose.value
         del state, options
         vector = ravel_vector(vector, packed_structures)
+        n_full, n_min = a.shape
+        r = a[:n_min]
         if transpose:
-            # Minimal norm solution if underdetermined.
-            solution = q.conj() @ jsp.linalg.solve_triangular(
-                r, vector, trans="T", unit_diagonal=False
-            )
+            # Minimal norm solution if underdetermined: x = Q.conj() @ R^{-T} @ b.
+            # Use Q.conj() @ z = (z^T @ Q^H)^T to avoid explicit `conj` calls,
+            # and pad `y` along the row axis to absorb the discarded columns of Q.
+            y = jsp.linalg.solve_triangular(r, vector, trans="T", unit_diagonal=False)
+            zeros = jnp.zeros((1, n_full - n_min), dtype=y.dtype)
+            y_pad = jnp.concatenate([y[None, :], zeros], axis=1)
+            solution = jll.ormqr(a, taus, y_pad, left=False, transpose=True)[0]
         else:
             # Least squares solution if overdetermined.
+            qHv = jll.ormqr(a, taus, vector[:, None], transpose=True)[:n_min, 0]
             solution = jsp.linalg.solve_triangular(
-                r, q.T.conj() @ vector, trans="N", unit_diagonal=False
+                r, qHv, trans="N", unit_diagonal=False
             )
         solution = unravel_solution(solution, packed_structures)
         return solution, RESULTS.successful, {}
 
     def transpose(self, state: _QRState, options: dict[str, Any]):
-        (q, r), transpose, structures = state
+        (a, taus), transpose, structures = state
         transposed_packed_structures = transpose_packed_structures(structures)
         transpose_state = (
-            (q, r),
+            (a, taus),
             eqxi.Static(not transpose.value),
             transposed_packed_structures,
         )
@@ -97,9 +105,9 @@ class QR(AbstractLinearSolver):
         return transpose_state, transpose_options
 
     def conj(self, state: _QRState, options: dict[str, Any]):
-        (q, r), transpose, structures = state
+        (a, taus), transpose, structures = state
         conj_state = (
-            (q.conj(), r.conj()),
+            (a.conj(), taus.conj()),
             transpose,
             structures,
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,13 +47,13 @@ classifiers = [
   "Topic :: Scientific/Engineering :: Information Analysis",
   "Topic :: Scientific/Engineering :: Mathematics"
 ]
-dependencies = ["jax>=0.6.1", "jaxtyping>=0.2.24", "equinox>=0.11.10", "typing_extensions>=4.5.0"]
+dependencies = ["jax>=0.10.0", "jaxtyping>=0.2.24", "equinox>=0.11.10", "typing_extensions>=4.5.0"]
 description = "Linear solvers in JAX and Equinox."
 keywords = ["jax", "neural-networks", "deep-learning", "equinox", "linear-solvers", "least-squares", "numerical-methods"]
 license = {file = "LICENSE"}
 name = "lineax"
 readme = "README.md"
-requires-python = "~=3.10"
+requires-python = "~=3.11"
 urls = {repository = "https://github.com/google/lineax"}
 version = "0.1.0"
 


### PR DESCRIPTION
Typically on CPU this leads to a pretty stable 1.5x speedup in a QR solve (a 1000 times speed up in the multiplication itself but factorisation is still a heavy part of the solve), on GPU wins are mostly for large matrices but when https://github.com/jax-ml/jax/pull/36575 is merged wins will be realised across the board (sometimes by >8x). We just adopt this as the default and hide complexity from the user.

I think this is the last change I'd like to make before the next release.

@adconner I'd appreciate a quick pass over sanity check if you have time. I'm very aware that your pivoted QR PR is still open, my current thinking is that we should focus on doing a more complete least square focussed release next. The first foundation that I think might be help is having max rank tags and tracking rather than passing this to the solver. However, if you'd find this useful and rather it released now rather than in a few months I can try help iterate with you on a temporary design (I'm currently leaning towards the `QR(pivoted=True)` scipy/numpy homage API rather than `PivotedQR`).

@patrick-kidger note this means I have to bump Jax's minimum version to 0.10.0, are you comfortable with this? Does this have any implications on what version we should call the next release.