### PR TITLE
stop Mul/DivLinearOperator converting static scalars to jax arrays

### DIFF
--- a/lineax/_operator.py
+++ b/lineax/_operator.py
@@ -34,7 +34,7 @@ from jaxtyping import (
     ArrayLike,
     Inexact,
     PyTree,  # pyright: ignore
-    Scalar,
+    ScalarLike,
     Shaped,
 )
 
@@ -208,8 +208,7 @@ class AbstractLinearOperator(eqx.Module):
         return AddLinearOperator(self, -other)
 
     def __mul__(self, other) -> "AbstractLinearOperator":
-        other = jnp.asarray(other)
-        if other.shape != ():
+        if np.ndim(other) != 0:
             raise ValueError("Can only multiply AbstractLinearOperators by scalars.")
         return MulLinearOperator(self, other)
 
@@ -222,8 +221,7 @@ class AbstractLinearOperator(eqx.Module):
         return ComposedLinearOperator(self, other)
 
     def __truediv__(self, other) -> "AbstractLinearOperator":
-        other = jnp.asarray(other)
-        if other.shape != ():
+        if np.ndim(other) != 0:
             raise ValueError("Can only divide AbstractLinearOperators by scalars.")
         return DivLinearOperator(self, other)
 
@@ -1043,7 +1041,7 @@ class MulLinearOperator(AbstractLinearOperator):
     """
 
     operator: AbstractLinearOperator
-    scalar: Scalar
+    scalar: ScalarLike
 
     def mv(self, vector):
         return (self.operator.mv(vector) ** ω * self.scalar).ω
@@ -1105,7 +1103,7 @@ class DivLinearOperator(AbstractLinearOperator):
     """
 
     operator: AbstractLinearOperator
-    scalar: Scalar
+    scalar: ScalarLike
 
     def mv(self, vector):
         with jax.numpy_dtype_promotion("standard"):
@@ -2119,12 +2117,20 @@ for check in (
         return check(operator.operator)
 
 
-# has_unit_diagonal is NOT preserved by scaling or negation
-@has_unit_diagonal.register(MulLinearOperator)
+# has_unit_diagonal is NOT preserved by negation
 @has_unit_diagonal.register(NegLinearOperator)
-@has_unit_diagonal.register(DivLinearOperator)
 def _(operator):
     return False
+
+
+# has_unit_diagonal is preserved by scaling/dividing only when scalar == 1
+@has_unit_diagonal.register(MulLinearOperator)
+@has_unit_diagonal.register(DivLinearOperator)
+def _(operator):
+    scalar = operator.scalar
+    if not isinstance(scalar, (int, float, np.ndarray, np.generic)):
+        return False
+    return float(scalar) == 1.0 and has_unit_diagonal(operator.operator)
 
 
 class _ScalarSign(enum.Enum):
@@ -2369,9 +2375,15 @@ def _(operator):
     return conj(operator.operator1) + conj(operator.operator2)
 
 
+def _scalar_conj(scalar):
+    if isinstance(scalar, (int, float, np.ndarray, np.generic)):
+        return np.conj(scalar)
+    return jnp.conj(scalar)
+
+
 @conj.register(MulLinearOperator)
 def _(operator):
-    return conj(operator.operator) * operator.scalar.conj()
+    return conj(operator.operator) * _scalar_conj(operator.scalar)
 
 
 @conj.register(NegLinearOperator)
@@ -2381,7 +2393,7 @@ def _(operator):
 
 @conj.register(DivLinearOperator)
 def _(operator):
-    return conj(operator.operator) / operator.scalar.conj()
+    return conj(operator.operator) / _scalar_conj(operator.scalar)
 
 
 @conj.register(ComposedLinearOperator)

--- a/lineax/_operator.py
+++ b/lineax/_operator.py
@@ -2376,7 +2376,14 @@ def _(operator):
 
 
 def _scalar_conj(scalar):
-    if isinstance(scalar, (int, float, np.ndarray, np.generic)):
+    # Preserve Python scalar types so that weak-typed Python ints/floats
+    # don't get promoted to numpy generics (which equinox treats as arrays
+    # and thus become strong-typed JAX tracers under strict dtype promotion).
+    if isinstance(scalar, (int, float)):
+        return scalar
+    if isinstance(scalar, complex):
+        return scalar.conjugate()
+    if isinstance(scalar, (np.ndarray, np.generic)):
         return np.conj(scalar)
     return jnp.conj(scalar)
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -309,18 +309,62 @@ def make_tridiagonal_operator(getkey, matrix, tags):
 
 
 @_operators_append
+def make_neg_operator(getkey, matrix, tags):
+    negated_tags = ()
+    if tags == lx.negative_semidefinite_tag:
+        tags = ()
+        negated_tags = lx.positive_semidefinite_tag
+    if tags == lx.positive_semidefinite_tag:
+        tags = ()
+        negated_tags = lx.negative_semidefinite_tag
+    return lx.TaggedLinearOperator(
+        -make_matrix_operator(getkey, -matrix, negated_tags), tags
+    )
+
+
+# tags that should be preserved under add and (POSITIVE) sclar mul/div
+PRESERVED_TAGS = {
+    lx.diagonal_tag,
+    lx.diagonal_tag,
+    lx.symmetric_tag,
+    lx.upper_triangular_tag,
+    lx.lower_triangular_tag,
+    lx.negative_semidefinite_tag,
+    lx.positive_semidefinite_tag,
+}
+
+
+@_operators_append
 def make_add_operator(getkey, matrix, tags):
+    preserved = ()
+    if tags in PRESERVED_TAGS:
+        preserved = tags
+        tags = ()
     matrix1 = 0.7 * matrix
     matrix2 = 0.3 * matrix
-    operator = make_matrix_operator(getkey, matrix1, ()) + make_function_operator(
-        getkey, matrix2, ()
-    )
+    operator = make_matrix_operator(
+        getkey, matrix1, preserved
+    ) + make_function_operator(getkey, matrix2, preserved)
+    return lx.TaggedLinearOperator(operator, tags)
+
+
+@_operators_append
+def make_div_operator(getkey, matrix, tags):
+    preserved = ()
+    if tags in PRESERVED_TAGS:
+        preserved = tags
+        tags = ()
+    operator = make_jac_operator(getkey, 0.7 * matrix, preserved) / 0.7
     return lx.TaggedLinearOperator(operator, tags)
 
 
 @_operators_append
 def make_mul_operator(getkey, matrix, tags):
-    operator = make_jac_operator(getkey, 0.7 * matrix, ()) / 0.7
+    preserved = ()
+    if tags in PRESERVED_TAGS:
+        preserved = tags
+        tags = ()
+    operator = make_jac_operator(getkey, 0.5 * matrix, preserved) * 2
     return lx.TaggedLinearOperator(operator, tags)
 
 

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -133,10 +133,13 @@ def _assert_except_diag(cond_fun, operators, flip_cond):
         _cond_fun = cond_fun
         cond_fun = lambda x: not _cond_fun(x)
     for operator in operators:
+        jitted_identity = eqx.filter_jit(lambda x: x)
         if isinstance(operator, lx.DiagonalLinearOperator):
             assert not cond_fun(operator)
+            assert not cond_fun(jitted_identity(operator))
         else:
             assert cond_fun(operator)
+            assert cond_fun(jitted_identity(operator))
 
 
 @pytest.mark.parametrize("dtype", (jnp.float64, jnp.complex128))
@@ -283,6 +286,9 @@ def test_has_unit_diagonal(dtype, getkey):
     matrix_unit_diag = matrix.at[jnp.arange(3), jnp.arange(3)].set(1)
     unit_diagonal = _setup(getkey, matrix_unit_diag, lx.unit_diagonal_tag)
     _assert_except_diag(lx.has_unit_diagonal, unit_diagonal, flip_cond=False)
+    assert not lx.has_unit_diagonal(
+        2 * lx.MatrixLinearOperator(matrix, tags=lx.unit_diagonal_tag)
+    )
 
 
 @pytest.mark.parametrize("dtype", (jnp.float64, jnp.complex128))


### PR DESCRIPTION
I realised that our psd/nsd tags weren't propagating with simple primitive multipliers, the culprit was simply `jnp.asarray` converting scalar to jax arrays which escaped detection, using `np.ndim` works in all cases.

The one things I'm not really sure about is whether it was worth adding the unit diagonal `1 *` and `/ 1` tests, it seems a bit niche but probably harmless. Happy to remove or keep as you prefer.

The way I updated the tests to catch this is somewhat nuanced and I'd appreciate a look whenever you get a small moment (no rush on this one!).