### PR TITLE
refactor: create invert tags helper

### DIFF
--- a/lineax/__init__.py
+++ b/lineax/__init__.py
@@ -69,10 +69,13 @@ from ._solver import (
 )
 from ._tags import (
     diagonal_tag as diagonal_tag,
+    invert_tags as invert_tags,
+    invert_tags_rules as invert_tags_rules,
     lower_triangular_tag as lower_triangular_tag,
     negative_semidefinite_tag as negative_semidefinite_tag,
     positive_semidefinite_tag as positive_semidefinite_tag,
     symmetric_tag as symmetric_tag,
+    tags_from_checks as tags_from_checks,
     transpose_tags as transpose_tags,
     transpose_tags_rules as transpose_tags_rules,
     tridiagonal_tag as tridiagonal_tag,

--- a/lineax/_solve.py
+++ b/lineax/_solve.py
@@ -34,13 +34,11 @@ from ._operator import (
     AbstractLinearOperator,
     conj,
     FunctionLinearOperator,
-    has_unit_diagonal,
     IdentityLinearOperator,
     is_diagonal,
     is_lower_triangular,
     is_negative_semidefinite,
     is_positive_semidefinite,
-    is_symmetric,
     is_tridiagonal,
     is_upper_triangular,
     linearise,
@@ -48,13 +46,8 @@ from ._operator import (
 )
 from ._solution import RESULTS, Solution
 from ._tags import (
-    diagonal_tag,
-    lower_triangular_tag,
-    negative_semidefinite_tag,
-    positive_semidefinite_tag,
-    symmetric_tag,
-    unit_diagonal_tag,
-    upper_triangular_tag,
+    invert_tags,
+    tags_from_checks,
 )
 
 
@@ -850,25 +843,8 @@ def invert(
             throw=throw,
         ).value
 
-    tags = {
-        tag
-        for check, tag in [
-            (is_symmetric, symmetric_tag),
-            (is_diagonal, diagonal_tag),
-            (is_lower_triangular, lower_triangular_tag),
-            (is_upper_triangular, upper_triangular_tag),
-            (is_positive_semidefinite, positive_semidefinite_tag),
-            (is_negative_semidefinite, negative_semidefinite_tag),
-        ]
-        if check(operator)
-    }
-    if has_unit_diagonal(operator) and (
-        is_diagonal(operator)
-        or is_lower_triangular(operator)
-        or is_upper_triangular(operator)
-    ):
-        tags.add(unit_diagonal_tag)
-    return FunctionLinearOperator(solve_fn, operator.out_structure(), frozenset(tags))
+    tags = invert_tags(tags_from_checks(operator))
+    return FunctionLinearOperator(solve_fn, operator.out_structure(), tags)
 
 
 # Work around JAX issue #22011,

--- a/lineax/_tags.py
+++ b/lineax/_tags.py
@@ -12,6 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from ._operator import AbstractLinearOperator
+
 
 class _HasRepr:
     def __init__(self, string: str):
@@ -29,6 +35,53 @@ lower_triangular_tag = _HasRepr("lower_triangular_tag")
 upper_triangular_tag = _HasRepr("upper_triangular_tag")
 positive_semidefinite_tag = _HasRepr("positive_semidefinite_tag")
 negative_semidefinite_tag = _HasRepr("negative_semidefinite_tag")
+
+
+def tags_from_checks(operator: "AbstractLinearOperator") -> frozenset[object]:
+    """Inspects an operator using all standard property checks and
+    returns a frozenset of the tags that apply to it.
+
+    This is the canonical way to collect the full set of tags for any operator,
+    regardless of whether that operator stores its properties as an explicit `.tags`
+    frozenset or encodes them structurally (e.g. a `DiagonalLinearOperator`
+    is always diagonal).
+
+    **Arguments:**
+
+    - `operator`: the linear operator to inspect.
+
+    **Returns:**
+
+    A `frozenset` of tags.
+    """
+    # Lazy import to avoid a circular dependency: _operator.py imports _tags.py
+    # at module level, so we defer the reverse import to call time when both
+    # modules are fully initialised.
+    from ._operator import (
+        has_unit_diagonal,
+        is_diagonal,
+        is_lower_triangular,
+        is_negative_semidefinite,
+        is_positive_semidefinite,
+        is_symmetric,
+        is_tridiagonal,
+        is_upper_triangular,
+    )
+
+    return frozenset(
+        tag
+        for check, tag in [
+            (is_symmetric, symmetric_tag),
+            (is_diagonal, diagonal_tag),
+            (is_lower_triangular, lower_triangular_tag),
+            (is_upper_triangular, upper_triangular_tag),
+            (is_positive_semidefinite, positive_semidefinite_tag),
+            (is_negative_semidefinite, negative_semidefinite_tag),
+            (has_unit_diagonal, unit_diagonal_tag),
+            (is_tridiagonal, tridiagonal_tag),
+        ]
+        if check(operator)
+    )
 
 
 transpose_tags_rules = []
@@ -81,6 +134,69 @@ def transpose_tags(tags: frozenset[object]):
         return tags
     new_tags = []
     for rule in transpose_tags_rules:
+        out = rule(tags)
+        if out is not None:
+            new_tags.append(out)
+    return frozenset(new_tags)
+
+
+invert_tags_rules = []
+
+
+for tag in (
+    symmetric_tag,
+    diagonal_tag,
+    lower_triangular_tag,
+    upper_triangular_tag,
+    positive_semidefinite_tag,
+    negative_semidefinite_tag,
+):
+
+    @invert_tags_rules.append
+    def _(tags: frozenset[object], tag=tag):
+        if tag in tags:
+            return tag
+
+
+@invert_tags_rules.append
+def _(tags: frozenset[object]):
+    if unit_diagonal_tag in tags and (
+        diagonal_tag in tags
+        or lower_triangular_tag in tags
+        or upper_triangular_tag in tags
+    ):
+        return unit_diagonal_tag
+
+
+# tridiagonal_tag intentionally absent: inverse of tridiagonal matrix generally dense.
+
+
+def invert_tags(tags: frozenset[object]) -> frozenset[object]:
+    """Lineax uses "tags" to declare that a particular linear operator exhibits some
+    property, e.g. symmetry.
+
+    This function takes in a collection of tags representing a linear operator, and
+    returns a collection of tags that should be associated with the (pseudo)inverse
+    of that linear operator.
+
+    Most structural properties are preserved by inversion (symmetric, diagonal,
+    triangular, positive/negative semidefinite).  Notable exceptions:
+
+    - `tridiagonal_tag` is **not** preserved — the inverse of a tridiagonal matrix
+      is generally dense.
+    - `unit_diagonal_tag` is only preserved when the operator is also diagonal or
+      triangular.
+
+    **Arguments:**
+
+    - `tags`: a `frozenset` of tags.
+
+    **Returns:**
+
+    A `frozenset` of tags.
+    """
+    new_tags = []
+    for rule in invert_tags_rules:
         out = rule(tags)
         if out is not None:
             new_tags.append(out)


### PR DESCRIPTION
This mirrors the existing transpose_tags helper and simplifies the logic in _solve.py. The main goal is unifying tags logic so if a developer adds a new tag (e.g. the proposed `circulant_tag`  from discussions with @BalzaniEdoardo) they don't need to trace as much of the codebase. The tags_from_checks helper is the most janky due to its circular import with `_operatory.py` (solved with lazy importing and `TYPE_CHECKING` conditionals). Happy to move that to `_operator.py` if you prefer.