### PR TITLE
fix iterative breakdowns due to element-wise tolerances

### DIFF
--- a/lineax/_solver/bicgstab.py
+++ b/lineax/_solver/bicgstab.py
@@ -93,7 +93,7 @@ class BiCGStab(AbstractLinearSolver[_BiCGStabState]):
             and self.rtol == 0
         )
         if has_scale:
-            b_scale = (self.atol + self.rtol * ω(vector).call(jnp.abs)).ω
+            b_scale = self.atol + self.rtol * self.norm(vector)
 
         # This implementation is the same a jax.scipy.sparse.linalg.bicgstab
         # but with AbstractLinearOperator.
@@ -117,11 +117,16 @@ class BiCGStab(AbstractLinearSolver[_BiCGStabState]):
             # Given Ay=b, then we have to be doing better than `scale` in both
             # the `y` and the `b` spaces.
             if has_scale:
-                with jax.numpy_dtype_promotion("standard"):
-                    y_scale = (self.atol + self.rtol * ω(y).call(jnp.abs)).ω
-                    norm1 = self.norm((r**ω / b_scale**ω).ω)  # pyright: ignore
-                    norm2 = self.norm((diff**ω / y_scale**ω).ω)
-                return (norm1 > 1) | (norm2 > 1)
+                # Standard relative-residual stopping rule: ‖r‖ ≤ atol + rtol·‖b‖
+                # (and likewise for the increment in the `y` space). Note this uses
+                # scalar norms, *not* an elementwise `atol + rtol·|b|` scale: the
+                # latter is unsatisfiable for wide-dynamic-range `b`, where the
+                # round-off floor of large components exceeds the absolute tolerance
+                # demanded of small ones, yielding spurious non-convergence.
+                y_scale = self.atol + self.rtol * self.norm(y)
+                b_unconverged = self.norm(r) > b_scale  # pyright: ignore
+                y_unconverged = self.norm(diff) > y_scale
+                return b_unconverged | y_unconverged
             else:
                 return True
 

--- a/lineax/_solver/cg.py
+++ b/lineax/_solver/cg.py
@@ -17,7 +17,6 @@ from collections.abc import Callable
 from typing import Any, TypeAlias
 
 import equinox.internal as eqxi
-import jax
 import jax.lax as lax
 import jax.numpy as jnp
 import jax.tree_util as jtu
@@ -144,18 +143,23 @@ class CG(AbstractLinearSolver[_CGState]):
             and self.rtol == 0
         )
         if has_scale:
-            b_scale = (self.atol + self.rtol * ω(vector).call(jnp.abs)).ω
+            b_scale = self.atol + self.rtol * self.norm(vector)
 
         def not_converged(r, diff, y):
             # The primary tolerance check.
             # Given Ay=b, then we have to be doing better than `scale` in both
             # the `y` and the `b` spaces.
             if has_scale:
-                with jax.numpy_dtype_promotion("standard"):
-                    y_scale = (self.atol + self.rtol * ω(y).call(jnp.abs)).ω
-                    norm1 = self.norm((r**ω / b_scale**ω).ω)  # pyright: ignore
-                    norm2 = self.norm((diff**ω / y_scale**ω).ω)
-                return (norm1 > 1) | (norm2 > 1)
+                # Standard relative-residual stopping rule: ‖r‖ ≤ atol + rtol·‖b‖
+                # (and likewise for the increment in the `y` space). Note this uses
+                # scalar norms, *not* an elementwise `atol + rtol·|b|` scale: the
+                # latter is unsatisfiable for wide-dynamic-range `b`, where the
+                # round-off floor of large components exceeds the absolute tolerance
+                # demanded of small ones, yielding spurious non-convergence.
+                y_scale = self.atol + self.rtol * self.norm(y)
+                b_unconverged = self.norm(r) > b_scale  # pyright: ignore
+                y_unconverged = self.norm(diff) > y_scale
+                return b_unconverged | y_unconverged
             else:
                 return True
 

--- a/lineax/_solver/gmres.py
+++ b/lineax/_solver/gmres.py
@@ -116,7 +116,7 @@ class GMRES(AbstractLinearSolver[_GMRESState]):
             and self.rtol == 0
         )
         if has_scale:
-            b_scale = (self.atol + self.rtol * ω(vector).call(jnp.abs)).ω
+            b_scale = self.atol + self.rtol * self.norm(vector)
         operator = state
         preconditioner, y0 = preconditioner_and_y0(operator, vector, options)
         leaves, _ = jtu.tree_flatten(vector)
@@ -132,11 +132,16 @@ class GMRES(AbstractLinearSolver[_GMRESState]):
             # Given Ay=b, then we have to be doing better than `scale` in both
             # the `y` and the `b` spaces.
             if has_scale:
-                with jax.numpy_dtype_promotion("standard"):
-                    y_scale = (self.atol + self.rtol * ω(y).call(jnp.abs)).ω
-                    norm1 = self.norm((r**ω / b_scale**ω).ω)  # pyright: ignore
-                    norm2 = self.norm((diff**ω / y_scale**ω).ω)
-                return (norm1 > 1) | (norm2 > 1)
+                # Standard relative-residual stopping rule: ‖r‖ ≤ atol + rtol·‖b‖
+                # (and likewise for the increment in the `y` space). Note this uses
+                # scalar norms, *not* an elementwise `atol + rtol·|b|` scale: the
+                # latter is unsatisfiable for wide-dynamic-range `b`, where the
+                # round-off floor of large components exceeds the absolute tolerance
+                # demanded of small ones, yielding spurious non-convergence.
+                y_scale = self.atol + self.rtol * self.norm(y)
+                b_unconverged = self.norm(r) > b_scale  # pyright: ignore
+                y_unconverged = self.norm(diff) > y_scale
+                return b_unconverged | y_unconverged
             else:
                 return True
 


### PR DESCRIPTION
A flaky GMRES test on #228 led me down a rabbit hole to realise that all iterative solvers except for LSMR have been using nonlinear solver style element-wise convergence checks (e.g. Hairer–Nørsett–Wanner) to handle elements with hugely differing scale, i.e.:

```python
b_scale = (self.atol + self.rtol * ω(vector).call(jnp.abs)).ω
y_scale = (self.atol + self.rtol * ω(y).call(jnp.abs)).ω
norm1 = self.norm((r**ω / b_scale**ω).ω)
norm2 = self.norm((diff**ω / y_scale**ω).ω)
return (norm1 > 1) | (norm2 > 1)
```

However, for iterative LINEAR solvers RHS elements of different scales will inevitably mix unless the matrix is sufficiently sparse leading to round-off error that to "iterative breakdowns". These cases can crop up randomly in the tests.

MWE:

```python
A = jnp.array([[1.0, 0.5, 0.3],
               [0.2, 2.0, 0.7],
               [0.6, 0.1, 1.5]])
b = jnp.array([1e8, 1.0, 1.0])

lx.linear_solve(lx.MatrixLinearOperator(A), b, lx.GMRES(rtol=1e-12, atol=1e-12))
# -> equinox.EquinoxRuntimeError: A form of iterative breakdown has occurred ...

# ...even though the system is solved essentially perfectly:

sol = lx.linear_solve(lx.MatrixLinearOperator(A), b,
                      lx.GMRES(rtol=1e-12, atol=1e-12), throw=False)
print(jnp.linalg.norm(A @ sol.value - b) / jnp.linalg.norm(b))   # 1.7e-16
print(jnp.allclose(sol.value, jnp.linalg.solve(A, b)))           # True
```

Note that the same solve passes at rtol=atol=1e-6 — the bug only bites when the requested tolerance dips near the achievable round-off floor.

This is fixed by adopting the standard convention (e.g. as in scipy) to only compare the norm of the vector to the tolerance:

```python
b_scale = self.atol + self.rtol * self.norm(vector)
y_scale = self.atol + self.rtol * self.norm(y)
return (self.norm(r) > b_scale) | (self.norm(diff) > y_scale)
```

@patrick-kidger this has been hugely long-standing (introduced in "initial commit") and I understand you might have some affinity towards the original approach. As such, I will await your oversight before merging this.