### PR TITLE
refactor: move Abstract/AutoLinearOperator to separate files to avoid circular imports

### DIFF
--- a/lineax/__init__.py
+++ b/lineax/__init__.py
@@ -49,11 +49,11 @@ from ._operator import (
 from ._solution import RESULTS as RESULTS, Solution as Solution
 from ._solve import (
     AbstractLinearSolver as AbstractLinearSolver,
-    AutoLinearSolver as AutoLinearSolver,
     invert as invert,
     linear_solve as linear_solve,
 )
 from ._solver import (
+    AutoLinearSolver as AutoLinearSolver,
     BiCGStab as BiCGStab,
     CG as CG,
     Cholesky as Cholesky,

--- a/lineax/_solve.py
+++ b/lineax/_solve.py
@@ -342,8 +342,6 @@ def _check_rank_compat(
             )
 
 
-# TODO(kidger): gmres, bicgstab
-# TODO(kidger): support auxiliary outputs
 @eqx.filter_jit
 def linear_solve(
     operator: AbstractLinearOperator,

--- a/lineax/_solve.py
+++ b/lineax/_solve.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import functools as ft
-from typing import Any, TypeAlias
+from typing import Any
 
 import equinox as eqx
 import equinox.internal as eqxi
@@ -25,7 +25,7 @@ import jax.numpy as jnp
 import jax.tree_util as jtu
 from equinox.internal import ω
 from jax._src.ad_util import stop_gradient_p
-from jaxtyping import Array, ArrayLike, PyTree
+from jaxtyping import ArrayLike, PyTree
 
 from ._custom_types import sentinel
 from ._misc import inexact_asarray, strip_weak_dtype
@@ -34,26 +34,12 @@ from ._operator import (
     conj,
     FunctionLinearOperator,
     IdentityLinearOperator,
-    is_diagonal,
-    is_lower_triangular,
-    is_negative_semidefinite,
-    is_positive_semidefinite,
-    is_tridiagonal,
-    is_upper_triangular,
     linearise,
     max_rank,
     TangentLinearOperator,
 )
 from ._solution import RESULTS, Solution
-from ._solver import (
-    Cholesky,
-    Diagonal,
-    LU,
-    QR,
-    SVD,
-    Triangular,
-    Tridiagonal,
-)
+from ._solver import AutoLinearSolver
 from ._solver.base import AbstractLinearSolver as AbstractLinearSolver
 from ._tags import (
     invert_tags,
@@ -354,142 +340,6 @@ def _check_rank_compat(
                 "`AutoLinearSolver(well_posed=False)` or `lineax.SVD()`) to handle "
                 "rank-deficient systems via the pseudoinverse."
             )
-
-
-_AutoLinearSolverState: TypeAlias = tuple[AbstractLinearSolver, Any]
-
-
-class AutoLinearSolver(AbstractLinearSolver[_AutoLinearSolverState]):
-    """Automatically determines a good linear solver based on the structure of the
-    operator.
-
-    - If `well_posed=True`:
-        - If the operator is diagonal, then use [`lineax.Diagonal`][].
-        - If the operator is tridiagonal, then use [`lineax.Tridiagonal`][].
-        - If the operator is triangular, then use [`lineax.Triangular`][].
-        - If the matrix is positive or negative (semi-)definite, then use
-            [`lineax.Cholesky`][].
-        - Else use [`lineax.LU`][].
-
-    This is a good choice if you want to be certain that an error is raised for
-    ill-posed systems.
-
-    - If `well_posed=False`:
-        - If the operator is diagonal, then use [`lineax.Diagonal`][].
-        - Else use [`lineax.SVD`][].
-
-    This is a good choice if you want to be certain that you can handle ill-posed
-    systems.
-
-    - If `well_posed=None`:
-        - If the operator is non-square, then use [`lineax.QR`][].
-        - If the operator is diagonal, then use [`lineax.Diagonal`][].
-        - If the operator is tridiagonal, then use [`lineax.Tridiagonal`][].
-        - If the operator is triangular, then use [`lineax.Triangular`][].
-        - If the matrix is positive or negative (semi-)definite, then use
-            [`lineax.Cholesky`][].
-        - Else, use [`lineax.LU`][].
-
-    This is a good choice if your primary concern is computational efficiency. It will
-    handle ill-posed systems as long as it is not computationally expensive to do so.
-    """
-
-    well_posed: bool | None
-
-    def _select_solver(self, operator: AbstractLinearOperator) -> AbstractLinearSolver:
-        if self.well_posed is True:
-            if operator.in_size() != operator.out_size():
-                raise ValueError(
-                    "Cannot use `AutoLinearSolver(well_posed=True)` with a non-square "
-                    "operator. If you are trying solve a least-squares problem then "
-                    "you should pass `solver=AutoLinearSolver(well_posed=False)`. By "
-                    "default `lineax.linear_solve` assumes that the operator is "
-                    "square and nonsingular."
-                )
-            if is_diagonal(operator):
-                solver = Diagonal(well_posed=True)
-            elif is_tridiagonal(operator):
-                solver = Tridiagonal()
-            elif is_lower_triangular(operator) or is_upper_triangular(operator):
-                solver = Triangular()
-            elif is_positive_semidefinite(operator) or is_negative_semidefinite(
-                operator
-            ):
-                solver = Cholesky()
-            else:
-                solver = LU()
-        elif self.well_posed is False:
-            if is_diagonal(operator):
-                solver = Diagonal()
-            else:
-                # TODO: use rank-revealing QR instead.
-                solver = SVD()
-        elif self.well_posed is None:
-            if operator.in_size() != operator.out_size():
-                solver = QR()
-            elif is_diagonal(operator):
-                solver = Diagonal()
-            elif is_tridiagonal(operator):
-                solver = Tridiagonal()
-            elif is_lower_triangular(operator) or is_upper_triangular(operator):
-                solver = Triangular()
-            elif is_positive_semidefinite(operator) or is_negative_semidefinite(
-                operator
-            ):
-                solver = Cholesky()
-            else:
-                solver = LU()
-        else:
-            raise ValueError(f"Invalid value `well_posed={self.well_posed}`.")
-        return solver
-
-    def select_solver(self, operator: AbstractLinearOperator) -> AbstractLinearSolver:
-        """Check which solver that [`lineax.AutoLinearSolver`][] will dispatch to.
-
-        **Arguments:**
-
-        - `operator`: a linear operator.
-
-        **Returns:**
-
-        The linear solver that will be used.
-        """
-        return self._select_solver(operator)
-
-    def init(self, operator, options) -> _AutoLinearSolverState:
-        solver = self._select_solver(operator)
-        return solver, solver.init(operator, options)
-
-    def compute(
-        self,
-        state: _AutoLinearSolverState,
-        vector: PyTree[Array],
-        options: dict[str, Any],
-    ) -> tuple[PyTree[Array], RESULTS, dict[str, Any]]:
-        solver, state = state
-        solution, result, _ = solver.compute(state, vector, options)
-        return solution, result, {}
-
-    def transpose(self, state: _AutoLinearSolverState, options: dict[str, Any]):
-        solver, state = state
-        transpose_state, transpose_options = solver.transpose(state, options)
-        transpose_state = (solver, transpose_state)
-        return transpose_state, transpose_options
-
-    def conj(self, state: _AutoLinearSolverState, options: dict[str, Any]):
-        solver, state = state
-        conj_state, conj_options = solver.conj(state, options)
-        conj_state = (solver, conj_state)
-        return conj_state, conj_options
-
-    def assume_full_rank(self):
-        return self.well_posed is not False
-
-
-AutoLinearSolver.__init__.__doc__ = """**Arguments:**
-
-- `well_posed`: whether to only handle well-posed systems or not, as discussed above.
-"""
 
 
 # TODO(kidger): gmres, bicgstab

--- a/lineax/_solve.py
+++ b/lineax/_solve.py
@@ -12,9 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import abc
 import functools as ft
-from typing import Any, Generic, TypeAlias, TypeVar
+from typing import Any, TypeAlias
 
 import equinox as eqx
 import equinox.internal as eqxi
@@ -46,6 +45,16 @@ from ._operator import (
     TangentLinearOperator,
 )
 from ._solution import RESULTS, Solution
+from ._solver import (
+    Cholesky,
+    Diagonal,
+    LU,
+    QR,
+    SVD,
+    Triangular,
+    Tridiagonal,
+)
+from ._solver.base import AbstractLinearSolver as AbstractLinearSolver
 from ._tags import (
     invert_tags,
     tags_from_checks,
@@ -331,149 +340,6 @@ eqxi.register_impl_finalisation(linear_solve_p)
 #
 
 
-_SolverState = TypeVar("_SolverState")
-
-
-class AbstractLinearSolver(eqx.Module, Generic[_SolverState]):
-    """Abstract base class for all linear solvers."""
-
-    @abc.abstractmethod
-    def init(
-        self, operator: AbstractLinearOperator, options: dict[str, Any]
-    ) -> _SolverState:
-        """Do any initial computation on just the `operator`.
-
-        For example, an LU solver would compute the LU decomposition of the operator
-        (and this does not require knowing the vector yet).
-
-        It is common to need to solve the linear system `Ax=b` multiple times in
-        succession, with the same operator `A` and multiple vectors `b`. This method
-        improves efficiency by making it possible to re-use the computation performed
-        on just the operator.
-
-        !!! Example
-
-            ```python
-            operator = lx.MatrixLinearOperator(...)
-            vector1 = ...
-            vector2 = ...
-            solver = lx.LU()
-            state = solver.init(operator, options={})
-            solution1 = lx.linear_solve(operator, vector1, solver, state=state)
-            solution2 = lx.linear_solve(operator, vector2, solver, state=state)
-            ```
-
-        **Arguments:**
-
-        - `operator`: a linear operator.
-        - `options`: a dictionary of any extra options that the solver may wish to
-            accept.
-
-        **Returns:**
-
-        A PyTree of arbitrary Python objects.
-        """
-
-    @abc.abstractmethod
-    def compute(
-        self, state: _SolverState, vector: PyTree[Array], options: dict[str, Any]
-    ) -> tuple[PyTree[Array], RESULTS, dict[str, Any]]:
-        """Solves a linear system.
-
-        **Arguments:**
-
-        - `state`: as returned from [`lineax.AbstractLinearSolver.init`][].
-        - `vector`: the vector to solve against.
-        - `options`: a dictionary of any extra options that the solver may wish to
-            accept. For example, [`lineax.CG`][] accepts a `preconditioner` option.
-
-        **Returns:**
-
-        A 3-tuple of:
-
-        - The solution to the linear system.
-        - An integer indicating the success or failure of the solve. This is an integer
-            which may be converted to a human-readable error message via
-            `lx.RESULTS[...]`.
-        - A dictionary of an extra statistics about the solve, e.g. the number of steps
-            taken.
-        """
-
-    @abc.abstractmethod
-    def transpose(
-        self, state: _SolverState, options: dict[str, Any]
-    ) -> tuple[_SolverState, dict[str, Any]]:
-        """Transposes the result of [`lineax.AbstractLinearSolver.init`][].
-
-        That is, it should be the case that
-        ```python
-        state_transpose, _ = solver.transpose(solver.init(operator, options), options)
-        state_transpose2 = solver.init(operator.T, options)
-        ```
-        must be identical to each other.
-
-        It is relatively common (in particular when differentiating through a linear
-        solve) to need to solve both `Ax = b` and `A^T x = b`. This method makes it
-        possible to avoid computing both `solver.init(operator)` and
-        `solver.init(operator.T)` if one can be cheaply computed from the other.
-
-        **Arguments:**
-
-        - `state`: as returned from `solver.init`.
-        - `options`: any extra options that were passed to `solve.init`.
-
-        **Returns:**
-
-        A 2-tuple of:
-
-        - The state of the transposed operator.
-        - The options for the transposed operator.
-        """
-
-    @abc.abstractmethod
-    def conj(
-        self, state: _SolverState, options: dict[str, Any]
-    ) -> tuple[_SolverState, dict[str, Any]]:
-        """Conjugate the result of [`lineax.AbstractLinearSolver.init`][].
-
-        That is, it should be the case that
-        ```python
-        state_conj, _ = solver.conj(solver.init(operator, options), options)
-        state_conj2 = solver.init(conj(operator), options)
-        ```
-        must be identical to each other.
-
-        **Arguments:**
-
-        - `state`: as returned from `solver.init`.
-        - `options`: any extra options that were passed to `solve.init`.
-
-        **Returns:**
-
-        A 2-tuple of:
-
-        - The state of the conjugated operator.
-        - The options for the conjugated operator.
-        """
-
-    @abc.abstractmethod
-    def assume_full_rank(self) -> bool:
-        """Does this solver assume that all operators are full rank?
-
-        When `False`, a more expensive backward pass is needed to account for
-        the extra generality. In a custom linear solver, it is always safe to
-        return False.
-
-        **Arguments:**
-
-        Nothing.
-
-        **Returns:**
-
-        Either `True` or `False`.
-        """
-
-
 def _check_rank_compat(
     solver: "AbstractLinearSolver", operator: AbstractLinearOperator
 ):
@@ -490,39 +356,7 @@ def _check_rank_compat(
             )
 
 
-_qr_token = eqxi.str2jax("qr_token")
-_diagonal_token = eqxi.str2jax("diagonal_token")
-_well_posed_diagonal_token = eqxi.str2jax("well_posed_diagonal_token")
-_tridiagonal_token = eqxi.str2jax("tridiagonal_token")
-_triangular_token = eqxi.str2jax("triangular_token")
-_cholesky_token = eqxi.str2jax("cholesky_token")
-_lu_token = eqxi.str2jax("lu_token")
-_svd_token = eqxi.str2jax("svd_token")
-
-
-# Ugly delayed import because we have the dependency chain
-# linear_solve -> AutoLinearSolver -> {Cholesky,...} -> AbstractLinearSolver
-# but we want linear_solver and AbstractLinearSolver in the same file.
-def _lookup(token) -> AbstractLinearSolver:
-    from . import _solver
-
-    # pyright doesn't know that these keys are hashable
-    _lookup_dict = {
-        _qr_token: _solver.QR(),  # pyright: ignore
-        _diagonal_token: _solver.Diagonal(),  # pyright: ignore
-        _well_posed_diagonal_token: _solver.Diagonal(  # pyright: ignore
-            well_posed=True
-        ),
-        _tridiagonal_token: _solver.Tridiagonal(),  # pyright: ignore
-        _triangular_token: _solver.Triangular(),  # pyright: ignore
-        _cholesky_token: _solver.Cholesky(),  # pyright: ignore
-        _lu_token: _solver.LU(),  # pyright: ignore
-        _svd_token: _solver.SVD(),  # pyright: ignore
-    }
-    return _lookup_dict[token]
-
-
-_AutoLinearSolverState: TypeAlias = tuple[Any, Any]
+_AutoLinearSolverState: TypeAlias = tuple[AbstractLinearSolver, Any]
 
 
 class AutoLinearSolver(AbstractLinearSolver[_AutoLinearSolverState]):
@@ -562,7 +396,7 @@ class AutoLinearSolver(AbstractLinearSolver[_AutoLinearSolverState]):
 
     well_posed: bool | None
 
-    def _select_solver(self, operator: AbstractLinearOperator):
+    def _select_solver(self, operator: AbstractLinearOperator) -> AbstractLinearSolver:
         if self.well_posed is True:
             if operator.in_size() != operator.out_size():
                 raise ValueError(
@@ -573,41 +407,41 @@ class AutoLinearSolver(AbstractLinearSolver[_AutoLinearSolverState]):
                     "square and nonsingular."
                 )
             if is_diagonal(operator):
-                token = _well_posed_diagonal_token
+                solver = Diagonal(well_posed=True)
             elif is_tridiagonal(operator):
-                token = _tridiagonal_token
+                solver = Tridiagonal()
             elif is_lower_triangular(operator) or is_upper_triangular(operator):
-                token = _triangular_token
+                solver = Triangular()
             elif is_positive_semidefinite(operator) or is_negative_semidefinite(
                 operator
             ):
-                token = _cholesky_token
+                solver = Cholesky()
             else:
-                token = _lu_token
+                solver = LU()
         elif self.well_posed is False:
             if is_diagonal(operator):
-                token = _diagonal_token
+                solver = Diagonal()
             else:
                 # TODO: use rank-revealing QR instead.
-                token = _svd_token
+                solver = SVD()
         elif self.well_posed is None:
             if operator.in_size() != operator.out_size():
-                token = _qr_token
+                solver = QR()
             elif is_diagonal(operator):
-                token = _diagonal_token
+                solver = Diagonal()
             elif is_tridiagonal(operator):
-                token = _tridiagonal_token
+                solver = Tridiagonal()
             elif is_lower_triangular(operator) or is_upper_triangular(operator):
-                token = _triangular_token
+                solver = Triangular()
             elif is_positive_semidefinite(operator) or is_negative_semidefinite(
                 operator
             ):
-                token = _cholesky_token
+                solver = Cholesky()
             else:
-                token = _lu_token
+                solver = LU()
         else:
             raise ValueError(f"Invalid value `well_posed={self.well_posed}`.")
-        return token
+        return solver
 
     def select_solver(self, operator: AbstractLinearOperator) -> AbstractLinearSolver:
         """Check which solver that [`lineax.AutoLinearSolver`][] will dispatch to.
@@ -620,11 +454,11 @@ class AutoLinearSolver(AbstractLinearSolver[_AutoLinearSolverState]):
 
         The linear solver that will be used.
         """
-        return _lookup(self._select_solver(operator))
+        return self._select_solver(operator)
 
     def init(self, operator, options) -> _AutoLinearSolverState:
-        token = self._select_solver(operator)
-        return token, _lookup(token).init(operator, options)
+        solver = self._select_solver(operator)
+        return solver, solver.init(operator, options)
 
     def compute(
         self,
@@ -632,23 +466,20 @@ class AutoLinearSolver(AbstractLinearSolver[_AutoLinearSolverState]):
         vector: PyTree[Array],
         options: dict[str, Any],
     ) -> tuple[PyTree[Array], RESULTS, dict[str, Any]]:
-        token, state = state
-        solver = _lookup(token)
+        solver, state = state
         solution, result, _ = solver.compute(state, vector, options)
         return solution, result, {}
 
     def transpose(self, state: _AutoLinearSolverState, options: dict[str, Any]):
-        token, state = state
-        solver = _lookup(token)
+        solver, state = state
         transpose_state, transpose_options = solver.transpose(state, options)
-        transpose_state = (token, transpose_state)
+        transpose_state = (solver, transpose_state)
         return transpose_state, transpose_options
 
     def conj(self, state: _AutoLinearSolverState, options: dict[str, Any]):
-        token, state = state
-        solver = _lookup(token)
+        solver, state = state
         conj_state, conj_options = solver.conj(state, options)
-        conj_state = (token, conj_state)
+        conj_state = (solver, conj_state)
         return conj_state, conj_options
 
     def assume_full_rank(self):

--- a/lineax/_solver/__init__.py
+++ b/lineax/_solver/__init__.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from .auto import AutoLinearSolver as AutoLinearSolver
 from .bicgstab import BiCGStab as BiCGStab
 from .cg import CG as CG, NormalCG as NormalCG
 from .cholesky import Cholesky as Cholesky

--- a/lineax/_solver/auto.py
+++ b/lineax/_solver/auto.py
@@ -1,0 +1,172 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any, TypeAlias
+
+from jaxtyping import Array, PyTree
+
+from .._operator import (
+    AbstractLinearOperator,
+    is_diagonal,
+    is_lower_triangular,
+    is_negative_semidefinite,
+    is_positive_semidefinite,
+    is_tridiagonal,
+    is_upper_triangular,
+)
+from .._solution import RESULTS
+from .base import AbstractLinearSolver
+from .cholesky import Cholesky
+from .diagonal import Diagonal
+from .lu import LU
+from .qr import QR
+from .svd import SVD
+from .triangular import Triangular
+from .tridiagonal import Tridiagonal
+
+
+_AutoLinearSolverState: TypeAlias = tuple[AbstractLinearSolver, Any]
+
+
+class AutoLinearSolver(AbstractLinearSolver[_AutoLinearSolverState]):
+    """Automatically determines a good linear solver based on the structure of the
+    operator.
+
+    - If `well_posed=True`:
+        - If the operator is diagonal, then use [`lineax.Diagonal`][].
+        - If the operator is tridiagonal, then use [`lineax.Tridiagonal`][].
+        - If the operator is triangular, then use [`lineax.Triangular`][].
+        - If the matrix is positive or negative (semi-)definite, then use
+            [`lineax.Cholesky`][].
+        - Else use [`lineax.LU`][].
+
+    This is a good choice if you want to be certain that an error is raised for
+    ill-posed systems.
+
+    - If `well_posed=False`:
+        - If the operator is diagonal, then use [`lineax.Diagonal`][].
+        - Else use [`lineax.SVD`][].
+
+    This is a good choice if you want to be certain that you can handle ill-posed
+    systems.
+
+    - If `well_posed=None`:
+        - If the operator is non-square, then use [`lineax.QR`][].
+        - If the operator is diagonal, then use [`lineax.Diagonal`][].
+        - If the operator is tridiagonal, then use [`lineax.Tridiagonal`][].
+        - If the operator is triangular, then use [`lineax.Triangular`][].
+        - If the matrix is positive or negative (semi-)definite, then use
+            [`lineax.Cholesky`][].
+        - Else, use [`lineax.LU`][].
+
+    This is a good choice if your primary concern is computational efficiency. It will
+    handle ill-posed systems as long as it is not computationally expensive to do so.
+    """
+
+    well_posed: bool | None
+
+    def _select_solver(self, operator: AbstractLinearOperator) -> AbstractLinearSolver:
+        if self.well_posed is True:
+            if operator.in_size() != operator.out_size():
+                raise ValueError(
+                    "Cannot use `AutoLinearSolver(well_posed=True)` with a non-square "
+                    "operator. If you are trying solve a least-squares problem then "
+                    "you should pass `solver=AutoLinearSolver(well_posed=False)`. By "
+                    "default `lineax.linear_solve` assumes that the operator is "
+                    "square and nonsingular."
+                )
+            if is_diagonal(operator):
+                solver = Diagonal(well_posed=True)
+            elif is_tridiagonal(operator):
+                solver = Tridiagonal()
+            elif is_lower_triangular(operator) or is_upper_triangular(operator):
+                solver = Triangular()
+            elif is_positive_semidefinite(operator) or is_negative_semidefinite(
+                operator
+            ):
+                solver = Cholesky()
+            else:
+                solver = LU()
+        elif self.well_posed is False:
+            if is_diagonal(operator):
+                solver = Diagonal()
+            else:
+                # TODO: use rank-revealing QR instead.
+                solver = SVD()
+        elif self.well_posed is None:
+            if operator.in_size() != operator.out_size():
+                solver = QR()
+            elif is_diagonal(operator):
+                solver = Diagonal()
+            elif is_tridiagonal(operator):
+                solver = Tridiagonal()
+            elif is_lower_triangular(operator) or is_upper_triangular(operator):
+                solver = Triangular()
+            elif is_positive_semidefinite(operator) or is_negative_semidefinite(
+                operator
+            ):
+                solver = Cholesky()
+            else:
+                solver = LU()
+        else:
+            raise ValueError(f"Invalid value `well_posed={self.well_posed}`.")
+        return solver
+
+    def select_solver(self, operator: AbstractLinearOperator) -> AbstractLinearSolver:
+        """Check which solver that [`lineax.AutoLinearSolver`][] will dispatch to.
+
+        **Arguments:**
+
+        - `operator`: a linear operator.
+
+        **Returns:**
+
+        The linear solver that will be used.
+        """
+        return self._select_solver(operator)
+
+    def init(self, operator, options) -> _AutoLinearSolverState:
+        solver = self._select_solver(operator)
+        return solver, solver.init(operator, options)
+
+    def compute(
+        self,
+        state: _AutoLinearSolverState,
+        vector: PyTree[Array],
+        options: dict[str, Any],
+    ) -> tuple[PyTree[Array], RESULTS, dict[str, Any]]:
+        solver, state = state
+        solution, result, _ = solver.compute(state, vector, options)
+        return solution, result, {}
+
+    def transpose(self, state: _AutoLinearSolverState, options: dict[str, Any]):
+        solver, state = state
+        transpose_state, transpose_options = solver.transpose(state, options)
+        transpose_state = (solver, transpose_state)
+        return transpose_state, transpose_options
+
+    def conj(self, state: _AutoLinearSolverState, options: dict[str, Any]):
+        solver, state = state
+        conj_state, conj_options = solver.conj(state, options)
+        conj_state = (solver, conj_state)
+        return conj_state, conj_options
+
+    def assume_full_rank(self):
+        return self.well_posed is not False
+
+
+AutoLinearSolver.__init__.__doc__ = """**Arguments:**
+
+- `well_posed`: whether to only handle well-posed systems or not, as discussed above.
+"""

--- a/lineax/_solver/base.py
+++ b/lineax/_solver/base.py
@@ -1,0 +1,165 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import abc
+from typing import Any, Generic, TypeVar
+
+import equinox as eqx
+from jaxtyping import Array, PyTree
+
+from .._operator import AbstractLinearOperator
+from .._solution import RESULTS
+
+
+_SolverState = TypeVar("_SolverState")
+
+
+class AbstractLinearSolver(eqx.Module, Generic[_SolverState]):
+    """Abstract base class for all linear solvers."""
+
+    @abc.abstractmethod
+    def init(
+        self, operator: AbstractLinearOperator, options: dict[str, Any]
+    ) -> _SolverState:
+        """Do any initial computation on just the `operator`.
+
+        For example, an LU solver would compute the LU decomposition of the operator
+        (and this does not require knowing the vector yet).
+
+        It is common to need to solve the linear system `Ax=b` multiple times in
+        succession, with the same operator `A` and multiple vectors `b`. This method
+        improves efficiency by making it possible to re-use the computation performed
+        on just the operator.
+
+        !!! Example
+
+            ```python
+            operator = lx.MatrixLinearOperator(...)
+            vector1 = ...
+            vector2 = ...
+            solver = lx.LU()
+            state = solver.init(operator, options={})
+            solution1 = lx.linear_solve(operator, vector1, solver, state=state)
+            solution2 = lx.linear_solve(operator, vector2, solver, state=state)
+            ```
+
+        **Arguments:**
+
+        - `operator`: a linear operator.
+        - `options`: a dictionary of any extra options that the solver may wish to
+            accept.
+
+        **Returns:**
+
+        A PyTree of arbitrary Python objects.
+        """
+
+    @abc.abstractmethod
+    def compute(
+        self, state: _SolverState, vector: PyTree[Array], options: dict[str, Any]
+    ) -> tuple[PyTree[Array], RESULTS, dict[str, Any]]:
+        """Solves a linear system.
+
+        **Arguments:**
+
+        - `state`: as returned from [`lineax.AbstractLinearSolver.init`][].
+        - `vector`: the vector to solve against.
+        - `options`: a dictionary of any extra options that the solver may wish to
+            accept. For example, [`lineax.CG`][] accepts a `preconditioner` option.
+
+        **Returns:**
+
+        A 3-tuple of:
+
+        - The solution to the linear system.
+        - An integer indicating the success or failure of the solve. This is an integer
+            which may be converted to a human-readable error message via
+            `lx.RESULTS[...]`.
+        - A dictionary of an extra statistics about the solve, e.g. the number of steps
+            taken.
+        """
+
+    @abc.abstractmethod
+    def transpose(
+        self, state: _SolverState, options: dict[str, Any]
+    ) -> tuple[_SolverState, dict[str, Any]]:
+        """Transposes the result of [`lineax.AbstractLinearSolver.init`][].
+
+        That is, it should be the case that
+        ```python
+        state_transpose, _ = solver.transpose(solver.init(operator, options), options)
+        state_transpose2 = solver.init(operator.T, options)
+        ```
+        must be identical to each other.
+
+        It is relatively common (in particular when differentiating through a linear
+        solve) to need to solve both `Ax = b` and `A^T x = b`. This method makes it
+        possible to avoid computing both `solver.init(operator)` and
+        `solver.init(operator.T)` if one can be cheaply computed from the other.
+
+        **Arguments:**
+
+        - `state`: as returned from `solver.init`.
+        - `options`: any extra options that were passed to `solve.init`.
+
+        **Returns:**
+
+        A 2-tuple of:
+
+        - The state of the transposed operator.
+        - The options for the transposed operator.
+        """
+
+    @abc.abstractmethod
+    def conj(
+        self, state: _SolverState, options: dict[str, Any]
+    ) -> tuple[_SolverState, dict[str, Any]]:
+        """Conjugate the result of [`lineax.AbstractLinearSolver.init`][].
+
+        That is, it should be the case that
+        ```python
+        state_conj, _ = solver.conj(solver.init(operator, options), options)
+        state_conj2 = solver.init(conj(operator), options)
+        ```
+        must be identical to each other.
+
+        **Arguments:**
+
+        - `state`: as returned from `solver.init`.
+        - `options`: any extra options that were passed to `solve.init`.
+
+        **Returns:**
+
+        A 2-tuple of:
+
+        - The state of the conjugated operator.
+        - The options for the conjugated operator.
+        """
+
+    @abc.abstractmethod
+    def assume_full_rank(self) -> bool:
+        """Does this solver assume that all operators are full rank?
+
+        When `False`, a more expensive backward pass is needed to account for
+        the extra generality. In a custom linear solver, it is always safe to
+        return False.
+
+        **Arguments:**
+
+        Nothing.
+
+        **Returns:**
+
+        Either `True` or `False`.
+        """

--- a/lineax/_solver/bicgstab.py
+++ b/lineax/_solver/bicgstab.py
@@ -25,7 +25,7 @@ from jaxtyping import Array, PyTree
 from .._norm import max_norm, tree_dot
 from .._operator import AbstractLinearOperator, conj, linearise
 from .._solution import RESULTS
-from .._solve import AbstractLinearSolver
+from .base import AbstractLinearSolver
 from .misc import preconditioner_and_y0
 
 

--- a/lineax/_solver/cg.py
+++ b/lineax/_solver/cg.py
@@ -34,7 +34,7 @@ from .._operator import (
     linearise,
 )
 from .._solution import RESULTS
-from .._solve import AbstractLinearSolver
+from .base import AbstractLinearSolver
 from .misc import preconditioner_and_y0
 from .normal import Normal
 

--- a/lineax/_solver/cholesky.py
+++ b/lineax/_solver/cholesky.py
@@ -25,7 +25,7 @@ from .._operator import (
     is_positive_semidefinite,
 )
 from .._solution import RESULTS
-from .._solve import AbstractLinearSolver
+from .base import AbstractLinearSolver
 
 
 _CholeskyState: TypeAlias = tuple[Array, eqxi.Static]

--- a/lineax/_solver/diagonal.py
+++ b/lineax/_solver/diagonal.py
@@ -20,7 +20,7 @@ from jaxtyping import Array, PyTree
 from .._misc import resolve_rcond
 from .._operator import AbstractLinearOperator, diagonal, has_unit_diagonal, is_diagonal
 from .._solution import RESULTS
-from .._solve import AbstractLinearSolver
+from .base import AbstractLinearSolver
 from .misc import (
     pack_structures,
     PackedStructures,

--- a/lineax/_solver/gmres.py
+++ b/lineax/_solver/gmres.py
@@ -28,7 +28,7 @@ from .._misc import structure_equal
 from .._norm import max_norm, two_norm
 from .._operator import AbstractLinearOperator, conj, linearise, MatrixLinearOperator
 from .._solution import RESULTS
-from .._solve import AbstractLinearSolver, linear_solve
+from .base import AbstractLinearSolver
 from .misc import preconditioner_and_y0
 from .qr import QR
 
@@ -300,6 +300,8 @@ class GMRES(AbstractLinearSolver[_GMRESState]):
             )
             coeff_op_transpose = MatrixLinearOperator(coeff_mat.T)
             # TODO(raderj): move to a Hessenberg-specific solver
+            from .._solve import linear_solve
+
             z = linear_solve(coeff_op_transpose, beta_vec, QR(), throw=False).value
             diff = jtu.tree_map(
                 lambda mat: jnp.tensordot(

--- a/lineax/_solver/lsmr.py
+++ b/lineax/_solver/lsmr.py
@@ -46,7 +46,7 @@ from .._misc import complex_to_real_dtype
 from .._norm import two_norm
 from .._operator import AbstractLinearOperator, conj, linearise, max_rank
 from .._solution import RESULTS
-from .._solve import AbstractLinearSolver
+from .base import AbstractLinearSolver
 
 
 _LSMRState: TypeAlias = AbstractLinearOperator

--- a/lineax/_solver/lu.py
+++ b/lineax/_solver/lu.py
@@ -21,7 +21,7 @@ from jaxtyping import Array, PyTree
 
 from .._operator import AbstractLinearOperator, is_diagonal
 from .._solution import RESULTS
-from .._solve import AbstractLinearSolver
+from .base import AbstractLinearSolver
 from .misc import (
     pack_structures,
     PackedStructures,

--- a/lineax/_solver/normal.py
+++ b/lineax/_solver/normal.py
@@ -18,10 +18,16 @@ from typing import Any, TypeVar
 import equinox.internal as eqxi
 from jaxtyping import Array, PyTree
 
-from .._operator import conj, linearise, materialise, TaggedLinearOperator
+from .._operator import (
+    AbstractLinearOperator,
+    conj,
+    linearise,
+    materialise,
+    TaggedLinearOperator,
+)
 from .._solution import RESULTS
-from .._solve import AbstractLinearOperator, AbstractLinearSolver
 from .._tags import positive_semidefinite_tag
+from .base import AbstractLinearSolver
 from .cholesky import Cholesky
 
 

--- a/lineax/_solver/qr.py
+++ b/lineax/_solver/qr.py
@@ -21,7 +21,7 @@ import jax.scipy as jsp
 from jaxtyping import Array, PyTree
 
 from .._solution import RESULTS
-from .._solve import AbstractLinearSolver
+from .base import AbstractLinearSolver
 from .misc import (
     pack_structures,
     PackedStructures,

--- a/lineax/_solver/svd.py
+++ b/lineax/_solver/svd.py
@@ -23,7 +23,7 @@ from jaxtyping import Array, PyTree
 from .._misc import resolve_rcond
 from .._operator import AbstractLinearOperator, max_rank
 from .._solution import RESULTS
-from .._solve import AbstractLinearSolver
+from .base import AbstractLinearSolver
 from .misc import (
     pack_structures,
     PackedStructures,

--- a/lineax/_solver/triangular.py
+++ b/lineax/_solver/triangular.py
@@ -25,7 +25,7 @@ from .._operator import (
     is_upper_triangular,
 )
 from .._solution import RESULTS
-from .._solve import AbstractLinearSolver
+from .base import AbstractLinearSolver
 from .misc import (
     pack_structures,
     PackedStructures,

--- a/lineax/_solver/tridiagonal.py
+++ b/lineax/_solver/tridiagonal.py
@@ -20,7 +20,7 @@ from jaxtyping import Array, PyTree
 
 from .._operator import AbstractLinearOperator, is_tridiagonal, tridiagonal
 from .._solution import RESULTS
-from .._solve import AbstractLinearSolver
+from .base import AbstractLinearSolver
 from .misc import (
     pack_structures,
     PackedStructures,


### PR DESCRIPTION
@patrick-kidger the current setup has been causing me headaches trying to come up with more elegant designs for the jvp fast paths I tried out in #217 (such as creating private type aliases for subsets of solvers in _solve.py for type hinting and isinstance checking that depend on having access to solvers at module level). Moving AbstractLinearOperator solves a lot as it depends on nothing. We now have the much cleaner dependency tree

AbstractLinearOperator (now in _solver/base.py) -> concrete solvers (in _solver/) -> AutoLinearSolver (now in _solver/auto.py) -> linear_solve(_p) (still in _solve.py)

Is there any good reason not to move AbstractLinearOperator to its own file? It seems to clean up a lot. There is now just one circular import in GMRES which uses linear_solve internally which is generally a case worth special treatment (and actually one on the laundry list of moderate inefficiencies to address).

Moving AutoLinearSolver doesn't actually solve any problem, I just couldn't see a reason not to do it and I like the conceptual neatness of having all solvers in `_solver/`